### PR TITLE
chore(sonar): fix 11 low-risk code smells

### DIFF
--- a/src/app/store/config/egx.ts
+++ b/src/app/store/config/egx.ts
@@ -14,7 +14,11 @@ import type {
 } from '@/libs/pixsaur-egx'
 
 // Re-export types for convenience
-export type { EGXFirstLineMode, EGXPreviewMode, EGXType }
+export type {
+  EGXFirstLineMode,
+  EGXPreviewMode,
+  EGXType
+} from '@/libs/pixsaur-egx'
 
 // Also export as EgxType for consistency
 export type EgxType = EGXType

--- a/src/app/store/palette/palette.ts
+++ b/src/app/store/palette/palette.ts
@@ -51,7 +51,7 @@ export const userPaletteAtom = atom(
     const stored = get(paletteStorageAtom)
     // Convertir les arrays en tuples Vector<'RGB'>
     return stored.map((slot) => ({
-      color: slot.color as Vector<'RGB'> | null,
+      color: slot.color,
       locked: slot.locked
     })) as PaletteSlot[]
   },
@@ -59,7 +59,7 @@ export const userPaletteAtom = atom(
     const prev = get(paletteStorageAtom)
     // Convertir pour la comparaison
     const prevPalette = prev.map((slot) => ({
-      color: slot.color as Vector<'RGB'> | null,
+      color: slot.color,
       locked: slot.locked
     })) as PaletteSlot[]
 
@@ -106,9 +106,7 @@ export const onClearSlotAtom = atom(null, (get, set, idx: number) => {
 
 export const lockedVectorsAtom = atom((get) => {
   const { nColors } = get(effectiveModeConfigAtom)
-  return extractLockedColors(
-    get(userPaletteAtom).slice(0, nColors)
-  ) as Vector<'RGB'>[]
+  return extractLockedColors(get(userPaletteAtom).slice(0, nColors))
 })
 
 // Compte le nombre de slots vides verrouilles (pour reduire le nombre de couleurs a generer)

--- a/src/components/export-panel/use-export-actions.ts
+++ b/src/components/export-panel/use-export-actions.ts
@@ -238,11 +238,10 @@ export function useExportActions(): UseExportActions {
     notify
   ])
 
-  const canExport = modeREnabled
-    ? !!modeRExportData
-    : egxEnabled
-      ? !!egxExportData
-      : !!finalPreviewIndexBuffer
+  const fallbackCanExport = egxEnabled
+    ? !!egxExportData
+    : !!finalPreviewIndexBuffer
+  const canExport = modeREnabled ? !!modeRExportData : fallbackCanExport
 
   return {
     canExport,

--- a/src/components/preview-editor/editor-canvas/editor-canvas-view.tsx
+++ b/src/components/preview-editor/editor-canvas/editor-canvas-view.tsx
@@ -214,7 +214,7 @@ export const EditorCanvasView = forwardRef<
     // Draw hover highlight (if different from cursor)
     const shouldShowHover =
       hoveredPixel &&
-      (!cursor || hoveredPixel.x !== cursor.x || hoveredPixel.y !== cursor.y)
+      (hoveredPixel.x !== cursor?.x || hoveredPixel.y !== cursor?.y)
 
     if (shouldShowHover) {
       renderHover(

--- a/src/domain/cpc/mode-config.ts
+++ b/src/domain/cpc/mode-config.ts
@@ -105,7 +105,7 @@ export function buildCpcModeKey(
   if (dimensionPreset === 'standard') {
     return pixelMode.toString() as CpcModeKey
   }
-  return `${pixelMode}-overscan` as CpcModeKey
+  return `${pixelMode}-overscan`
 }
 
 /**

--- a/src/editor/application/enter-edit-mode.ts
+++ b/src/editor/application/enter-edit-mode.ts
@@ -79,11 +79,8 @@ export function enterEditMode(input: EnterEditModeInput): EditSession {
   } = input
 
   // EGX1 uses Mode 1 dimensions (square pixels); EGX2 uses Mode 2 (tall pixels).
-  const pixelMode: PixelMode = egxEnabled
-    ? egxType === 'egx1'
-      ? 1
-      : 2
-    : configPixelMode
+  const egxPixelMode: PixelMode = egxType === 'egx1' ? 1 : 2
+  const pixelMode: PixelMode = egxEnabled ? egxPixelMode : configPixelMode
 
   return {
     originalBuffer: new Uint8Array(baseBufferRaw ?? effective.buffer),

--- a/src/libs/pixsaur-adapter/adapters/regl-processor.ts
+++ b/src/libs/pixsaur-adapter/adapters/regl-processor.ts
@@ -44,7 +44,7 @@ import { ReGLQuantizer } from './regl-quantizer'
  * Phase 1: Infrastructure ReGL prête avec fallback CPU
  */
 export class ReGLProcessor implements ImageProcessor {
-  readonly type: 'regl' | 'cpu-fallback'
+  readonly type: 'regl' | 'cpu-fallback' = 'cpu-fallback'
   readonly isAvailable: boolean
 
   // ReGL et quantizer (Phase 1: préparation pour GPU)
@@ -72,8 +72,6 @@ export class ReGLProcessor implements ImageProcessor {
   }
 
   constructor(regl?: REGL.Regl) {
-    this.type = 'cpu-fallback'
-
     // Évaluer si ReGL pourrait être utilisé
     this.reglCapabilities = this.evaluateReGLCapabilities()
 
@@ -576,7 +574,7 @@ export class ReGLProcessor implements ImageProcessor {
       const sharpen = adjustments.sharpen ?? 0
       const blur = adjustments.blur ?? 0
       const blurPasses = getBlurPassCount(blur)
-      const sharpenPasses = sharpen !== 0 ? 1 : 0
+      const sharpenPasses = sharpen === 0 ? 0 : 1
       convolutionPasses = blurPasses + sharpenPasses
 
       // Texture de sortie finale
@@ -710,11 +708,10 @@ export class ReGLProcessor implements ImageProcessor {
 
     // Lecture du résultat final
     const resultData = new Uint8ClampedArray(width * height * 4)
-    const finalFramebuffer = hasEdges
-      ? edgesFramebuffer
-      : hasConvolution
-        ? convolutionFramebuffer
-        : adjustmentFramebuffer
+    const nonEdgeFramebuffer = hasConvolution
+      ? convolutionFramebuffer
+      : adjustmentFramebuffer
+    const finalFramebuffer = hasEdges ? edgesFramebuffer : nonEdgeFramebuffer
     this.regl!.read({
       framebuffer: finalFramebuffer,
       data: new Uint8Array(resultData.buffer)

--- a/src/libs/pixsaur-adapter/adapters/regl-quantizer.ts
+++ b/src/libs/pixsaur-adapter/adapters/regl-quantizer.ts
@@ -533,8 +533,8 @@ export class ReGLQuantizer {
     const isLowColorImage = uniqueColorCount <= 16
 
     // Choisir la stratégie appropriée
-    let effectiveStrategy: PaletteStrategyName = (config.paletteStrategy ||
-      'frequency-balanced') as PaletteStrategyName
+    let effectiveStrategy: PaletteStrategyName =
+      config.paletteStrategy || 'frequency-balanced'
 
     // Pour les images low-color, extraire TOUTES les couleurs uniques au lieu d'utiliser le sampling
     // Ceci garantit que toutes les couleurs source sont passées à la stratégie distinct-mapping
@@ -547,7 +547,7 @@ export class ReGLQuantizer {
       // Image retro avec peu de couleurs: maximiser les couleurs distinctes
       effectiveStrategy = 'distinct-mapping'
       // Extraire TOUTES les couleurs uniques (pas de sampling)
-      sampledColors = extractUniqueColors(imageData.data, 32) as Vector[]
+      sampledColors = extractUniqueColors(imageData.data, 32)
       adapterLogger.info(
         `[ReGL] Low-color image detected (${uniqueColorCount} colors), extracted ${sampledColors.length} unique colors, using distinct-mapping strategy`
       )
@@ -892,10 +892,7 @@ export class ReGLQuantizer {
     )
 
     // Utiliser les helpers pour créer et trier les buckets de teinte
-    const hueBuckets = createHueBuckets(
-      colorFrequency as ColorFrequencyItem[],
-      diversityParams
-    )
+    const hueBuckets = createHueBuckets(colorFrequency, diversityParams)
 
     // Trier les buckets par fréquence
     const sortedBuckets = sortBucketsByFrequency(hueBuckets)

--- a/src/libs/pixsaur-adapter/cpu-convolution.ts
+++ b/src/libs/pixsaur-adapter/cpu-convolution.ts
@@ -100,14 +100,14 @@ export function applyConvolutionFilters(
     for (let pass = 0; pass < passes; pass++) {
       // Première passe: kernel interpolé, passes suivantes: full Gaussian
       const blurKernel = createBlurKernel(blur, pass)
-      result = applyConvolution3x3(result, blurKernel, 1.0)
+      result = applyConvolution3x3(result, blurKernel, 1)
     }
   }
 
   // Puis sharpen (si actif)
   if (sharpen !== 0) {
     const sharpenKernel = createSharpenKernel(Math.abs(sharpen))
-    result = applyConvolution3x3(result, sharpenKernel, 1.0)
+    result = applyConvolution3x3(result, sharpenKernel, 1)
   }
 
   return result

--- a/src/libs/pixsaur-adapter/factory.ts
+++ b/src/libs/pixsaur-adapter/factory.ts
@@ -10,7 +10,7 @@ import { ReGLProcessor } from './adapters/regl-processor'
 import type { ProcessorType } from './interfaces'
 
 export const processorFactory = {
-  async createBestProcessor(type: ProcessorType | string = 'gpu') {
+  async createBestProcessor(type: ProcessorType = 'gpu') {
     if (type === 'cpu') {
       return new ReGLProcessor(undefined)
     }

--- a/src/libs/pixsaur-color/src/map/map-and-dither.ts
+++ b/src/libs/pixsaur-color/src/map/map-and-dither.ts
@@ -83,6 +83,11 @@ interface OrderedCorrectionOptions {
   enabled: boolean
 }
 
+/** Shared default so callers that omit `correction` reuse one frozen object. */
+const DEFAULT_ORDERED_CORRECTION: OrderedCorrectionOptions = Object.freeze({
+  enabled: true
+})
+
 function resolveDiffusionCorrectionOptions(
   config: DitheringConfig
 ): DiffusionCorrectionOptions {
@@ -544,7 +549,7 @@ export function applyBlueNoiseDither(
   paletteOut: Uint8ClampedArray[],
   intensity: number,
   distFn: DistanceFn,
-  correction: OrderedCorrectionOptions = { enabled: true }
+  correction: OrderedCorrectionOptions = DEFAULT_ORDERED_CORRECTION
 ): Uint8ClampedArray {
   const out = new Uint8ClampedArray(width * height * 4)
   const pixelCS = new Float32Array(3)
@@ -1012,7 +1017,7 @@ function applyBayerDitherWithDynamicPalette(
   mode: BayerMode,
   intensity: number,
   distFn: DistanceFn,
-  correction: OrderedCorrectionOptions = { enabled: true }
+  correction: OrderedCorrectionOptions = DEFAULT_ORDERED_CORRECTION
 ): Uint8ClampedArray {
   const out = new Uint8ClampedArray(width * height * 4)
   const pixel = new Float32Array(3)
@@ -1134,7 +1139,7 @@ function applyBlueNoiseDitherWithDynamicPalette(
   getPaletteForLine: (y: number) => Vector[],
   intensity: number,
   distFn: DistanceFn,
-  correction: OrderedCorrectionOptions = { enabled: true }
+  correction: OrderedCorrectionOptions = DEFAULT_ORDERED_CORRECTION
 ): Uint8ClampedArray {
   const out = new Uint8ClampedArray(width * height * 4)
   const pixel = new Float32Array(3)
@@ -1318,7 +1323,7 @@ export function mapAndDitherWithDynamicPalette(
         width,
         height,
         getPaletteForLine,
-        mode as BayerMode,
+        mode,
         config.intensity,
         distFn,
         resolveOrderedCorrectionOptions(config)

--- a/src/libs/pixsaur-egx/dithering.ts
+++ b/src/libs/pixsaur-egx/dithering.ts
@@ -44,6 +44,15 @@ function computeEGXPaletteBounds(palette: Vector<'RGB'>[]): {
   return { min, max }
 }
 
+/**
+ * Build the per-pixel error clamp shared by the EGX error-diffusion ditherers.
+ * When correction is enabled, the quantization error is clamped to ±`clamp` to
+ * prevent smearing; otherwise it passes through unchanged.
+ */
+function makeErrorClamp(enabled: boolean, clamp: number) {
+  return (v: number) => (enabled ? Math.max(-clamp, Math.min(clamp, v)) : v)
+}
+
 // ============================================================================
 // EGX Pixel Grouping
 // ============================================================================
@@ -133,10 +142,7 @@ function applyEGXFloydSteinbergDithering(
   const bounds = useDiffusionCorrection
     ? computeEGXPaletteBounds(palette)
     : null
-  const clampErr = (v: number) =>
-    useDiffusionCorrection
-      ? Math.max(-ERROR_CLAMP, Math.min(ERROR_CLAMP, v))
-      : v
+  const clampErr = makeErrorClamp(useDiffusionCorrection, ERROR_CLAMP)
 
   // Floyd-Steinberg weights
   const FS_RIGHT = (7 / 16) * intensity
@@ -260,10 +266,7 @@ function applyEGXOstromoukhovDithering(
   const bounds = useDiffusionCorrection
     ? computeEGXPaletteBounds(palette)
     : null
-  const clampErr = (v: number) =>
-    useDiffusionCorrection
-      ? Math.max(-ERROR_CLAMP, Math.min(ERROR_CLAMP, v))
-      : v
+  const clampErr = makeErrorClamp(useDiffusionCorrection, ERROR_CLAMP)
 
   for (let y = 0; y < height; y++) {
     // Get the sub-palette limit for this line
@@ -517,10 +520,7 @@ function applyEGXAtkinsonDithering(
   const bounds = useDiffusionCorrection
     ? computeEGXPaletteBounds(palette)
     : null
-  const clampErr = (v: number) =>
-    useDiffusionCorrection
-      ? Math.max(-ERROR_CLAMP, Math.min(ERROR_CLAMP, v))
-      : v
+  const clampErr = makeErrorClamp(useDiffusionCorrection, ERROR_CLAMP)
 
   // Atkinson distributes 1/8 of error to 6 neighbors (total 6/8 = 3/4)
   const weight = (1 / 8) * intensity

--- a/src/libs/pixsaur-egx/dithering.ts
+++ b/src/libs/pixsaur-egx/dithering.ts
@@ -617,14 +617,6 @@ export function applyEGXDitheringByMode(
     case 'none':
       result = applyEGXNoDithering(imageData, palette, config)
       break
-    case 'floydSteinberg':
-      result = applyEGXFloydSteinbergDithering(
-        imageData,
-        palette,
-        config,
-        intensity
-      )
-      break
     case 'ostromoukhov':
       result = applyEGXOstromoukhovDithering(
         imageData,
@@ -664,8 +656,8 @@ export function applyEGXDitheringByMode(
       )
       break
     default:
-      // For unsupported modes (ylioluma1, ylioluma2, halftone4x4),
-      // fall back to Floyd-Steinberg
+      // Floyd-Steinberg, plus the fallback for unsupported modes
+      // (ylioluma1, ylioluma2, halftone4x4).
       result = applyEGXFloydSteinbergDithering(
         imageData,
         palette,

--- a/src/libs/pixsaur-mode-r/pair-optimizer.ts
+++ b/src/libs/pixsaur-mode-r/pair-optimizer.ts
@@ -632,7 +632,7 @@ export function optimizeModeRPalettes(
 ): ModeRPalettes {
   // Generate uniform weights if not provided
   const weights =
-    targetWeights && targetWeights.length === targetColors.length
+    targetWeights?.length === targetColors.length
       ? targetWeights
       : targetColors.map(() => 1 / targetColors.length)
 

--- a/src/libs/pixsaur-mode-r/quantize-mode-r.ts
+++ b/src/libs/pixsaur-mode-r/quantize-mode-r.ts
@@ -965,9 +965,9 @@ function propagateError(opts: PropagateErrorOptions): void {
   } = opts
 
   const clamp = (v: number) =>
-    errorClamp !== undefined
-      ? Math.max(-errorClamp, Math.min(errorClamp, v))
-      : v
+    errorClamp === undefined
+      ? v
+      : Math.max(-errorClamp, Math.min(errorClamp, v))
   const e0 = clamp(error[0])
   const e1 = clamp(error[1])
   const e2 = clamp(error[2])

--- a/src/libs/pixsaur-raster/index.ts
+++ b/src/libs/pixsaur-raster/index.ts
@@ -2,18 +2,11 @@
 export * from './color-quantization'
 export * from './ink-assignment'
 export * from './line-palette-optimizer'
-// Legacy re-exports for backward compatibility
-// TODO: Remove after migration complete
-export {
-  extractGlobalPaletteFromImage,
-  MODE_0_FIXED_COLORS,
-  MODE_0_RASTER_SLOTS,
-  MODE_0_TOTAL_COLORS,
-  type OptimizationOptions,
-  type OptimizationResult,
-  optimizeLinePalettesWithIndexBuffer,
-  quantizeToCPCPlus
-} from './line-palette-optimizer'
+// `quantizeToCPCPlus` is exported by both ./color-quantization and
+// ./line-palette-optimizer, so the star-exports above leave it ambiguous.
+// Re-export the raster-optimizer one explicitly; every other name from
+// ./line-palette-optimizer is already covered by its `export *`.
+export { quantizeToCPCPlus } from './line-palette-optimizer'
 export * from './median-cut'
 export * from './palette-selection'
 export * from './preprocess-raster'

--- a/src/libs/pixsaur-raster/ink-assignment.ts
+++ b/src/libs/pixsaur-raster/ink-assignment.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Vector } from '../pixsaur-color/src/type'
-import { colorKey, colorsEqual } from './palette-selection'
+import { colorKey } from './palette-selection'
 
 /**
  * Find the best assignment of line colors to ink indices.
@@ -69,4 +69,4 @@ export function assignColorsToInks(
 }
 
 // Re-export utilities for convenience
-export { colorKey, colorsEqual }
+export { colorKey, colorsEqual } from './palette-selection'

--- a/src/preview/image-processing/horizontal-resample.ts
+++ b/src/preview/image-processing/horizontal-resample.ts
@@ -88,7 +88,7 @@ function buildAxisTaps(
       const w = kernel(filter, (s - center) / scale)
       if (w === 0) continue
       // Edge clamp: replicate the border pixel for out-of-range taps.
-      const clamped = s < 0 ? 0 : s > srcLen - 1 ? srcLen - 1 : s
+      const clamped = Math.max(0, Math.min(s, srcLen - 1))
       indices.push(clamped)
       weights.push(w)
       sum += w
@@ -106,7 +106,7 @@ function buildAxisTaps(
 }
 
 function clamp01(v: number): number {
-  return v < 0 ? 0 : v > 1 ? 1 : v
+  return Math.max(0, Math.min(v, 1))
 }
 
 /**


### PR DESCRIPTION
## Résumé

Nettoyage SonarCloud — 2 lots de code smells à faible risque (~33 issues).

**Batch 1** : S7748 (fractions `.0`), S6582 (optional chaining), S7763 (`export…from`), S1871 (case dupliqué), S1135 (TODO barrel raster).

**Batch 2** : S4325 (casts inutiles), S3358 + S7766 (ternaires / Math.min), S7737 (default objet figé), S4144 (closure clampErr extraite), S7735 (conditions négées), S6571, S7757.

Aucun changement de comportement. typecheck + Biome + 2127 tests + guards ✅.