### PR TITLE
chore(sonar): batch 3 — re-exports, params, test & resilience fixes

### DIFF
--- a/src/app/store/editor/editor-state.ts
+++ b/src/app/store/editor/editor-state.ts
@@ -2,18 +2,18 @@ import { atom } from 'jotai'
 import type { PixelMode } from '@/app/store/config/types'
 // Domain types now live in the application layer; imported for local use and
 // re-exported below for the store's many consumers (preview pipeline, barrels).
-import {
-  type EditHistoryEntry,
-  MAX_HISTORY_SIZE,
-  type PixelEdit
-} from '@/editor/application/types'
+import type { EditHistoryEntry } from '@/editor/application/types'
 import { getAspectRatioMultipliers } from '@/export/cpc-calculations'
 import type { Vector } from '@/libs/pixsaur-color/src/type'
 import type { EGXConfig } from '@/libs/pixsaur-egx'
 import { getMaxColorIndex, getModeForLine } from '@/libs/pixsaur-egx'
 import type { RasterChange } from '@/libs/pixsaur-raster/types'
 
-export { type EditHistoryEntry, MAX_HISTORY_SIZE, type PixelEdit }
+export type { EditHistoryEntry }
+export {
+  MAX_HISTORY_SIZE,
+  type PixelEdit
+} from '@/editor/application/types'
 
 // ============================================================================
 // État de l'éditeur de preview

--- a/src/app/use-unsaved-changes-warning.ts
+++ b/src/app/use-unsaved-changes-warning.ts
@@ -16,9 +16,10 @@ export function useUnsavedChangesWarning() {
     if (!hasManualEdits) return
 
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      // Per the current spec, calling preventDefault() is enough to trigger the
+      // browser's native "leave site?" confirmation (the legacy returnValue
+      // assignment is deprecated).
       event.preventDefault()
-      // Legacy requirement: some browsers need returnValue set to show the prompt.
-      event.returnValue = ''
     }
 
     globalThis.addEventListener('beforeunload', handleBeforeUnload)

--- a/src/components/error-boundary/error-fallback.tsx
+++ b/src/components/error-boundary/error-fallback.tsx
@@ -4,10 +4,10 @@ import Icon from '@/components/ui/icon'
 import { isDevelopment } from '@/core'
 import styles from './error-boundary.module.css'
 
-export type ErrorFallbackProps = {
+export type ErrorFallbackProps = Readonly<{
   error: Error | null
   onReset: () => void
-}
+}>
 
 /**
  * User-facing recovery UI rendered when a render-time error is caught by

--- a/src/libs/pixsaur-adapter/adapters/regl-processor.spec.ts
+++ b/src/libs/pixsaur-adapter/adapters/regl-processor.spec.ts
@@ -649,9 +649,13 @@ describe('ReGLProcessor', () => {
         writable: true
       })
 
-      processor.applyAdjustmentsSync(imageData, mockAdjustmentConfig)
+      const result = processor.applyAdjustmentsSync(
+        imageData,
+        mockAdjustmentConfig
+      )
 
       // Les logs de performance sont gérés par adapterLogger, mocké au niveau global
+      expect(result).toBeInstanceOf(ImageData)
     })
 
     test("devrait logger les informations d'initialisation", () => {

--- a/src/libs/pixsaur-mode-r/gpu-quantizer.ts
+++ b/src/libs/pixsaur-mode-r/gpu-quantizer.ts
@@ -56,6 +56,17 @@ const BAYER_MATRICES: Record<string, { size: number; data: number[] }> = {
 /**
  * GPU-accelerated Mode R quantizer using ReGL
  */
+export interface ModeRQuantizeParams {
+  imageData: Uint8ClampedArray
+  width: number
+  height: number
+  palettes: ModeRPalettes
+  flickerWeight: number
+  maxLuminanceDelta: number
+  ditheringMode?: DitheringMode | 'none'
+  ditheringIntensity?: number
+}
+
 export class ModeRGPUQuantizer {
   private readonly regl: REGL.Regl
   private quantizeCommand?: REGL.DrawCommand
@@ -242,16 +253,19 @@ export class ModeRGPUQuantizer {
    * Quantize image using GPU
    * Returns index buffers A and B
    */
-  quantize(
-    imageData: Uint8ClampedArray,
-    width: number,
-    height: number,
-    palettes: ModeRPalettes,
-    flickerWeight: number,
-    maxLuminanceDelta: number,
-    ditheringMode: DitheringMode | 'none' = 'bayer4x4',
-    ditheringIntensity: number = 50
-  ): { indexBufferA: Uint8Array; indexBufferB: Uint8Array } | null {
+  quantize({
+    imageData,
+    width,
+    height,
+    palettes,
+    flickerWeight,
+    maxLuminanceDelta,
+    ditheringMode = 'bayer4x4',
+    ditheringIntensity = 50
+  }: ModeRQuantizeParams): {
+    indexBufferA: Uint8Array
+    indexBufferB: Uint8Array
+  } | null {
     if (!this.isInitialized || !this.quantizeCommand) {
       logger.warn('[Mode R GPU] Not initialized, falling back to CPU')
       return null

--- a/src/libs/pixsaur-mode-r/quantize-mode-r.ts
+++ b/src/libs/pixsaur-mode-r/quantize-mode-r.ts
@@ -333,14 +333,14 @@ export function quantizeModeR(
     const gpuQuantizer = getModeRGPUQuantizer()
     if (gpuQuantizer?.isAvailable()) {
       logger.info('[Mode R] Using GPU quantization')
-      const gpuResult = gpuQuantizer.quantize(
+      const gpuResult = gpuQuantizer.quantize({
         imageData,
         width,
         height,
         palettes,
-        config.antiFlickerWeight,
-        config.maxLuminanceDelta
-      )
+        flickerWeight: config.antiFlickerWeight,
+        maxLuminanceDelta: config.maxLuminanceDelta
+      })
       if (gpuResult) {
         // Count unique blends used
         const usedBlends = new Set<string>()

--- a/src/libs/pixsaur-raster/line-palette-optimizer.ts
+++ b/src/libs/pixsaur-raster/line-palette-optimizer.ts
@@ -311,7 +311,7 @@ export function optimizeLinePalettesWithIndexBuffer(
         )
 
     // Collect and apply changes
-    const lineChanges = collectLineChanges(
+    const lineChanges = collectLineChanges({
       line,
       currentPalette,
       newPalette,
@@ -321,7 +321,7 @@ export function optimizeLinePalettesWithIndexBuffer(
       data,
       width,
       quantizeColor
-    )
+    })
 
     // Apply maxChangesPerLine constraint
     const finalPalette = applyChangeLimit(
@@ -564,17 +564,29 @@ interface LineChange {
   impact: number
 }
 
-function collectLineChanges(
-  line: number,
-  currentPalette: Vector<'RGB'>[],
-  newPalette: Vector<'RGB'>[],
-  rasterSlotStart: number,
-  rasterSlotEnd: number,
-  existingChangeSet: Set<string>,
-  data: Uint8ClampedArray,
-  width: number,
+interface CollectLineChangesParams {
+  line: number
+  currentPalette: Vector<'RGB'>[]
+  newPalette: Vector<'RGB'>[]
+  rasterSlotStart: number
+  rasterSlotEnd: number
+  existingChangeSet: Set<string>
+  data: Uint8ClampedArray
+  width: number
   quantizeColor: (color: Vector<'RGB'>) => Vector<'RGB'>
-): LineChange[] {
+}
+
+function collectLineChanges({
+  line,
+  currentPalette,
+  newPalette,
+  rasterSlotStart,
+  rasterSlotEnd,
+  existingChangeSet,
+  data,
+  width,
+  quantizeColor
+}: CollectLineChangesParams): LineChange[] {
   const lineChanges: LineChange[] = []
 
   for (let inkIndex = rasterSlotStart; inkIndex < rasterSlotEnd; inkIndex++) {

--- a/src/libs/pixsaur-raster/preprocess-raster.ts
+++ b/src/libs/pixsaur-raster/preprocess-raster.ts
@@ -261,7 +261,7 @@ export function preprocessImageForRaster(
       .map(() => [0, 0, 0])
 
     if (shouldApplyDithering) {
-      processLineWithDithering(
+      processLineWithDithering({
         line,
         width,
         data,
@@ -270,7 +270,7 @@ export function preprocessImageForRaster(
         newVerticalError,
         quantizedPalette,
         ditheringIntensity
-      )
+      })
     } else {
       processLineWithoutDithering(
         line,
@@ -292,16 +292,27 @@ export function preprocessImageForRaster(
 // Line Processing Helpers
 // ============================================================================
 
-function processLineWithDithering(
-  line: number,
-  width: number,
-  data: Uint8ClampedArray,
-  outputData: Uint8ClampedArray,
-  verticalError: [number, number, number][],
-  newVerticalError: [number, number, number][],
-  quantizedPalette: Vector<'RGB'>[],
+interface ProcessLineWithDitheringParams {
+  line: number
+  width: number
+  data: Uint8ClampedArray
+  outputData: Uint8ClampedArray
+  verticalError: [number, number, number][]
+  newVerticalError: [number, number, number][]
+  quantizedPalette: Vector<'RGB'>[]
   ditheringIntensity: number
-): void {
+}
+
+function processLineWithDithering({
+  line,
+  width,
+  data,
+  outputData,
+  verticalError,
+  newVerticalError,
+  quantizedPalette,
+  ditheringIntensity
+}: ProcessLineWithDitheringParams): void {
   const lineStart = line * width * 4
   const horizError: [number, number, number][] = new Array(width)
     .fill(null)


### PR DESCRIPTION
## Résumé

Troisième lot de corrections SonarCloud (8 issues).

- **S6759** + **S1874** — corrige 2 issues du code résilience (props `Readonly`, `event.returnValue` déprécié) manquantes du merge squashé de #330.
- **S7763 ×2** — `MAX_HISTORY_SIZE` / `PixelEdit` ré-exportés via `export…from`.
- **S2699** — vraie assertion ajoutée au test de logging perf GPU.
- **S107 ×3** — `collectLineChanges`, `processLineWithDithering`, `ModeRGPUQuantizer.quantize` regroupés en objet d'options (un seul site d'appel chacun).

Aucun changement de comportement. typecheck + Biome + 2127 tests + guards ✅.

### Déféré
- S107 ×5 (dither dispatch + `selectFrequentColorsWithDiversity`)
- S5914 ×14 + S4325 ×1 + S6848 ×1 → à marquer **Accept** dans SonarCloud
- S3776 ×39 (complexité cognitive)