### PR TITLE
test(libs): cover 7 pure libraries (+149 tests)

### DIFF
--- a/src/libs/pixsaur-adapter/cpu-convolution.spec.ts
+++ b/src/libs/pixsaur-adapter/cpu-convolution.spec.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyChromaKey,
+  applyConvolution3x3,
+  applyConvolutionFilters,
+  applyMedianFilter,
+  applySobelEdgeDetection
+} from './cpu-convolution'
+
+type RGBA = [number, number, number, number]
+
+/** Build an ImageData of `width`×`height`, each pixel from `fill(x, y)`. */
+function makeImage(
+  width: number,
+  height: number,
+  fill: (x: number, y: number) => RGBA
+): ImageData {
+  const data = new Uint8ClampedArray(width * height * 4)
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const [r, g, b, a] = fill(x, y)
+      const idx = (y * width + x) * 4
+      data[idx] = r
+      data[idx + 1] = g
+      data[idx + 2] = b
+      data[idx + 3] = a
+    }
+  }
+  return new ImageData(data, width, height)
+}
+
+const uniform =
+  (r: number, g: number, b: number, a = 255) =>
+  (): RGBA => [r, g, b, a]
+
+const IDENTITY_KERNEL = [0, 0, 0, 0, 1, 0, 0, 0, 0]
+const BOX_BLUR_KERNEL = new Array(9).fill(1 / 9)
+
+describe('applyConvolution3x3', () => {
+  it('returns an identical copy when strength is 0', () => {
+    const img = makeImage(2, 2, (x, y) => [x * 50, y * 50, 10, 255])
+    const out = applyConvolution3x3(img, BOX_BLUR_KERNEL, 0)
+    expect(out.width).toBe(2)
+    expect(out.height).toBe(2)
+    expect(Array.from(out.data)).toEqual(Array.from(img.data))
+    expect(out.data).not.toBe(img.data) // a copy, not the same buffer
+  })
+
+  it('is a no-op with the identity kernel at full strength', () => {
+    const img = makeImage(3, 3, (x, y) => [x * 30, y * 30, 100, 200])
+    const out = applyConvolution3x3(img, IDENTITY_KERNEL, 1)
+    expect(Array.from(out.data)).toEqual(Array.from(img.data))
+  })
+
+  it('leaves a uniform image unchanged under a box blur', () => {
+    const img = makeImage(3, 3, uniform(100, 150, 200))
+    const out = applyConvolution3x3(img, BOX_BLUR_KERNEL, 1)
+    for (let i = 0; i < out.data.length; i += 4) {
+      expect(out.data[i]).toBe(100)
+      expect(out.data[i + 1]).toBe(150)
+      expect(out.data[i + 2]).toBe(200)
+    }
+  })
+
+  it('preserves the alpha channel', () => {
+    const img = makeImage(2, 2, (x) => [x * 80, 0, 0, 123])
+    const out = applyConvolution3x3(img, BOX_BLUR_KERNEL, 1)
+    for (let i = 3; i < out.data.length; i += 4) {
+      expect(out.data[i]).toBe(123)
+    }
+  })
+})
+
+describe('applyConvolutionFilters', () => {
+  it('returns the same image when both filters are off', () => {
+    const img = makeImage(2, 2, uniform(10, 20, 30))
+    expect(applyConvolutionFilters(img, 0, 0)).toBe(img)
+  })
+
+  it('runs the blur path and keeps dimensions', () => {
+    const img = makeImage(4, 4, (x, y) => [(x + y) * 20, 50, 50, 255])
+    const out = applyConvolutionFilters(img, 0, 1)
+    expect(out.width).toBe(4)
+    expect(out.height).toBe(4)
+    expect(out).not.toBe(img)
+  })
+
+  it('runs the sharpen path and keeps dimensions', () => {
+    const img = makeImage(4, 4, (x, y) => [(x + y) * 20, 50, 50, 255])
+    const out = applyConvolutionFilters(img, 1, 0)
+    expect(out.width).toBe(4)
+    expect(out.height).toBe(4)
+  })
+})
+
+describe('applyMedianFilter', () => {
+  it('returns the same image for radius <= 0', () => {
+    const img = makeImage(3, 3, uniform(50, 50, 50))
+    expect(applyMedianFilter(img, 0)).toBe(img)
+    expect(applyMedianFilter(img, -2)).toBe(img)
+  })
+
+  it('removes an isolated outlier pixel', () => {
+    const img = makeImage(3, 3, (x, y) =>
+      x === 1 && y === 1 ? [255, 255, 255, 255] : [100, 100, 100, 255]
+    )
+    const out = applyMedianFilter(img, 1)
+    const centerIdx = (1 * 3 + 1) * 4
+    // Median of eight 100s and one 255 is 100 — the spike is gone.
+    expect(out.data[centerIdx]).toBe(100)
+    expect(out.data[centerIdx + 1]).toBe(100)
+    expect(out.data[centerIdx + 2]).toBe(100)
+  })
+
+  it('clamps the radius and preserves alpha + dimensions', () => {
+    const img = makeImage(3, 3, uniform(40, 40, 40, 77))
+    const out = applyMedianFilter(img, 5) // clamped to 3
+    expect(out.width).toBe(3)
+    expect(out.height).toBe(3)
+    for (let i = 3; i < out.data.length; i += 4) {
+      expect(out.data[i]).toBe(77)
+    }
+  })
+})
+
+describe('applySobelEdgeDetection', () => {
+  it('returns the same image when strength is 0', () => {
+    const img = makeImage(3, 3, uniform(120, 120, 120))
+    expect(applySobelEdgeDetection(img, 0)).toBe(img)
+  })
+
+  it('reports no edges on a uniform image', () => {
+    const img = makeImage(3, 3, uniform(120, 80, 40))
+    const out = applySobelEdgeDetection(img, 1)
+    for (let i = 0; i < out.data.length; i += 4) {
+      expect(out.data[i]).toBe(0)
+      expect(out.data[i + 1]).toBe(0)
+      expect(out.data[i + 2]).toBe(0)
+    }
+  })
+
+  it('detects a vertical edge', () => {
+    // Left half black, right half white -> a strong edge down the middle.
+    const img = makeImage(4, 3, (x) =>
+      x < 2 ? [0, 0, 0, 255] : [255, 255, 255, 255]
+    )
+    const out = applySobelEdgeDetection(img, 1)
+    // The column straddling the transition must light up somewhere.
+    let maxMag = 0
+    for (let i = 0; i < out.data.length; i += 4)
+      maxMag = Math.max(maxMag, out.data[i])
+    expect(maxMag).toBeGreaterThan(0)
+  })
+})
+
+describe('applyChromaKey', () => {
+  it('replaces pixels matching the key within tolerance', () => {
+    const img = makeImage(2, 1, (x) =>
+      x === 0 ? [0, 255, 0, 255] : [200, 10, 10, 255]
+    )
+    const out = applyChromaKey(img, [0, 255, 0], 10)
+    // Pixel 0 (the key colour) becomes the default replacement (black).
+    expect(Array.from(out.data.slice(0, 4))).toEqual([0, 0, 0, 255])
+    // Pixel 1 is far from the key -> untouched.
+    expect(Array.from(out.data.slice(4, 8))).toEqual([200, 10, 10, 255])
+  })
+
+  it('honours a custom replacement colour and preserves alpha', () => {
+    const img = makeImage(1, 1, () => [10, 10, 10, 180])
+    const out = applyChromaKey(img, [10, 10, 10], 0, [50, 60, 70])
+    expect(Array.from(out.data)).toEqual([50, 60, 70, 180])
+  })
+
+  it('only matches exact colours when tolerance is 0', () => {
+    const img = makeImage(1, 1, () => [10, 10, 12, 255])
+    // distance^2 = 4 > 0 -> not replaced
+    const out = applyChromaKey(img, [10, 10, 10], 0, [0, 0, 0])
+    expect(Array.from(out.data)).toEqual([10, 10, 12, 255])
+  })
+})

--- a/src/libs/pixsaur-egx/dithering.spec.ts
+++ b/src/libs/pixsaur-egx/dithering.spec.ts
@@ -1,0 +1,460 @@
+import { describe, expect, it } from 'vitest'
+import type { Vector } from '@/libs/pixsaur-color/src/type'
+import {
+  applyEGXDitheringByMode,
+  colorDistanceSquared,
+  findClosestInSubset
+} from './dithering'
+import type { EGXConfig } from './types'
+import { getMaxColorIndex, getModeForLine } from './types'
+
+type RGBA = [number, number, number, number]
+
+/** Build an ImageData of `width`×`height`, each pixel from `fill(x, y)`. */
+function makeImage(
+  width: number,
+  height: number,
+  fill: (x: number, y: number) => RGBA
+): ImageData {
+  const data = new Uint8ClampedArray(width * height * 4)
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const [r, g, b, a] = fill(x, y)
+      const idx = (y * width + x) * 4
+      data[idx] = r
+      data[idx + 1] = g
+      data[idx + 2] = b
+      data[idx + 3] = a
+    }
+  }
+  return new ImageData(data, width, height)
+}
+
+const uniform =
+  (r: number, g: number, b: number, a = 255) =>
+  (): RGBA => [r, g, b, a]
+
+/**
+ * 16-colour EGX1 palette. The first 4 entries (INK 0-3) are the colours that
+ * Mode 1 (high-res) lines may use; the full 16 are available on Mode 0 lines.
+ * Kept simple and well separated so nearest-colour matches are unambiguous.
+ */
+const EGX1_PALETTE: Vector<'RGB'>[] = [
+  [0, 0, 0], // 0 black            (shared)
+  [255, 0, 0], // 1 red            (shared)
+  [0, 255, 0], // 2 green          (shared)
+  [0, 0, 255], // 3 blue           (shared)
+  [255, 255, 0], // 4 yellow
+  [255, 0, 255], // 5 magenta
+  [0, 255, 255], // 6 cyan
+  [255, 255, 255], // 7 white
+  [128, 0, 0], // 8
+  [0, 128, 0], // 9
+  [0, 0, 128], // 10
+  [128, 128, 0], // 11
+  [128, 0, 128], // 12
+  [0, 128, 128], // 13
+  [128, 128, 128], // 14
+  [64, 64, 64] // 15
+]
+
+/** 4-colour EGX2 palette (Mode 1 / Mode 2 alternation). */
+const EGX2_PALETTE: Vector<'RGB'>[] = [
+  [0, 0, 0], // 0 (shared, INK 0-1 usable on Mode 2 lines)
+  [255, 255, 255], // 1 (shared)
+  [255, 0, 0], // 2
+  [0, 0, 255] // 3
+]
+
+function makeConfig(overrides: Partial<EGXConfig> = {}): EGXConfig {
+  return {
+    type: 'egx1',
+    firstLineMode: 'low',
+    targetHardware: 'plus',
+    ditheringMode: 'floydSteinberg',
+    ditheringIntensity: 100,
+    ...overrides
+  }
+}
+
+/** Is `pixel` exactly equal to one of the first `maxIndex+1` palette colours? */
+function isInSubPalette(
+  pixel: [number, number, number],
+  palette: Vector<'RGB'>[],
+  maxIndex: number
+): boolean {
+  const limit = Math.min(maxIndex + 1, palette.length)
+  for (let i = 0; i < limit; i++) {
+    const c = palette[i]
+    if (c[0] === pixel[0] && c[1] === pixel[1] && c[2] === pixel[2]) return true
+  }
+  return false
+}
+
+/** Assert every output pixel uses a colour allowed on its line's sub-palette. */
+function expectAllColorsInSubPalette(
+  out: Uint8ClampedArray,
+  width: number,
+  height: number,
+  palette: Vector<'RGB'>[],
+  config: EGXConfig
+): void {
+  for (let y = 0; y < height; y++) {
+    const mode = getModeForLine(y, config)
+    const maxIndex = getMaxColorIndex(mode, config.type)
+    for (let x = 0; x < width; x++) {
+      const idx = (y * width + x) * 4
+      const pixel: [number, number, number] = [
+        out[idx],
+        out[idx + 1],
+        out[idx + 2]
+      ]
+      expect(
+        isInSubPalette(pixel, palette, maxIndex),
+        `pixel (${x},${y}) ${pixel.join(',')} not in sub-palette (mode ${mode}, maxIndex ${maxIndex})`
+      ).toBe(true)
+    }
+  }
+}
+
+const ALL_MODES = [
+  'none',
+  'floydSteinberg',
+  'ostromoukhov',
+  'atkinson',
+  'bayer2x2',
+  'bayer4x4',
+  'bayer8x8'
+] as const
+
+describe('applyEGXDitheringByMode', () => {
+  it.each(ALL_MODES)('preserves dimensions and alpha for mode %s', (mode) => {
+    const width = 4
+    const height = 2
+    const img = makeImage(width, height, (x, y) => [x * 60, y * 60, 30, 200])
+    const out = applyEGXDitheringByMode(
+      img,
+      EGX1_PALETTE,
+      makeConfig(),
+      mode,
+      1
+    )
+    expect(out).toBeInstanceOf(Uint8ClampedArray)
+    expect(out.length).toBe(width * height * 4)
+    // Alpha is always forced to 255 by every EGX ditherer.
+    for (let i = 3; i < out.length; i += 4) {
+      expect(out[i]).toBe(255)
+    }
+  })
+
+  it.each(ALL_MODES)(
+    'only emits sub-palette colours per line for mode %s',
+    (mode) => {
+      const width = 4
+      const height = 4
+      const config = makeConfig()
+      // A varied gradient so the high-res (4-colour) and low-res (16-colour)
+      // lines genuinely exercise their differing constraints.
+      const img = makeImage(width, height, (x, y) => [
+        x * 70,
+        y * 70,
+        (x + y) * 40,
+        255
+      ])
+      const out = applyEGXDitheringByMode(img, EGX1_PALETTE, config, mode, 1)
+      expectAllColorsInSubPalette(out, width, height, EGX1_PALETTE, config)
+    }
+  )
+
+  it.each(ALL_MODES)('produces no NaN for mode %s', (mode) => {
+    const width = 6
+    const height = 4
+    const img = makeImage(width, height, (x, y) => [
+      (x * 37) % 256,
+      (y * 53) % 256,
+      (x * y * 19) % 256,
+      255
+    ])
+    const out = applyEGXDitheringByMode(
+      img,
+      EGX1_PALETTE,
+      makeConfig(),
+      mode,
+      1
+    )
+    for (let i = 0; i < out.length; i++) {
+      expect(Number.isNaN(out[i])).toBe(false)
+    }
+  })
+
+  it('quantizes a uniform image to the nearest palette colour (no dithering)', () => {
+    // Pure red is palette index 1 (shared, valid on every line).
+    const img = makeImage(4, 4, uniform(250, 5, 5))
+    const out = applyEGXDitheringByMode(
+      img,
+      EGX1_PALETTE,
+      makeConfig(),
+      'none',
+      1
+    )
+    for (let i = 0; i < out.length; i += 4) {
+      expect(out[i]).toBe(255)
+      expect(out[i + 1]).toBe(0)
+      expect(out[i + 2]).toBe(0)
+      expect(out[i + 3]).toBe(255)
+    }
+  })
+
+  it('maps a uniform red image to red on every line for ordered dithering too', () => {
+    // Red is a shared colour, so even with Bayer perturbation it must remain
+    // the nearest match on both the 16-colour and 4-colour lines.
+    const img = makeImage(4, 4, uniform(255, 0, 0))
+    const out = applyEGXDitheringByMode(
+      img,
+      EGX1_PALETTE,
+      makeConfig(),
+      'bayer4x4',
+      1
+    )
+    for (let i = 0; i < out.length; i += 4) {
+      expect([out[i], out[i + 1], out[i + 2]]).toEqual([255, 0, 0])
+    }
+  })
+
+  it('restricts high-res (Mode 1) lines to INK 0-3 even when a closer Mode-0 colour exists', () => {
+    // Yellow (255,255,0) is palette index 4 — available only on Mode 0 lines.
+    // With firstLineMode 'low', odd lines are Mode 1 and must fall back to a
+    // shared colour (0-3) instead of index 4.
+    const config = makeConfig()
+    const img = makeImage(4, 2, uniform(255, 255, 0))
+    const out = applyEGXDitheringByMode(img, EGX1_PALETTE, config, 'none', 1)
+
+    // Even line (y=0): Mode 0, yellow available -> exact yellow.
+    const even = (0 * 4 + 0) * 4
+    expect([out[even], out[even + 1], out[even + 2]]).toEqual([255, 255, 0])
+
+    // Odd line (y=1): Mode 1, max index 3 -> must NOT be the yellow at index 4.
+    const odd = (1 * 4 + 0) * 4
+    const oddPixel: [number, number, number] = [
+      out[odd],
+      out[odd + 1],
+      out[odd + 2]
+    ]
+    expect(oddPixel).not.toEqual([255, 255, 0])
+    expect(isInSubPalette(oddPixel, EGX1_PALETTE, 3)).toBe(true)
+  })
+
+  it('enforces pixel grouping: low-res line pixel pairs share a colour', () => {
+    // On Mode-0 (low-res) lines, pairs of buffer pixels must end up identical.
+    // Make a checkerboard so an un-grouped result would differ across a pair.
+    const width = 4
+    const height = 2
+    const config = makeConfig()
+    const img = makeImage(width, height, (x) =>
+      x % 2 === 0 ? [255, 0, 0, 255] : [0, 255, 0, 255]
+    )
+    const out = applyEGXDitheringByMode(img, EGX1_PALETTE, config, 'none', 1)
+
+    // y=0 is the low-res (Mode 0) line — pairs (0,1) and (2,3) must match.
+    for (let x = 0; x < width; x += 2) {
+      const a = (0 * width + x) * 4
+      const b = (0 * width + x + 1) * 4
+      expect([out[a], out[a + 1], out[a + 2]]).toEqual([
+        out[b],
+        out[b + 1],
+        out[b + 2]
+      ])
+    }
+  })
+
+  it('falls back to Floyd-Steinberg for an unknown mode name', () => {
+    const img = makeImage(4, 2, (x, y) => [x * 60, y * 50, 80, 255])
+    const fs = applyEGXDitheringByMode(
+      img,
+      EGX1_PALETTE,
+      makeConfig(),
+      'floydSteinberg',
+      1
+    )
+    const unknown = applyEGXDitheringByMode(
+      img,
+      EGX1_PALETTE,
+      makeConfig(),
+      'halftone4x4',
+      1
+    )
+    expect(Array.from(unknown)).toEqual(Array.from(fs))
+  })
+
+  it('intensity 0 vs full intensity differ on a gradient (error diffusion off)', () => {
+    // With intensity 0, Floyd-Steinberg spreads no error -> equivalent to plain
+    // per-line quantization; a mid-tone gradient yields a different result than
+    // intensity 1 which diffuses error to neighbours.
+    const width = 8
+    const height = 4
+    const img = makeImage(width, height, (x) => {
+      const v = Math.round((x / (width - 1)) * 255)
+      return [v, v, v, 255]
+    })
+    const zero = applyEGXDitheringByMode(
+      img,
+      EGX1_PALETTE,
+      makeConfig(),
+      'floydSteinberg',
+      0
+    )
+    const full = applyEGXDitheringByMode(
+      img,
+      EGX1_PALETTE,
+      makeConfig(),
+      'floydSteinberg',
+      1
+    )
+    expect(Array.from(zero)).not.toEqual(Array.from(full))
+  })
+
+  it('intensity 0 floyd-steinberg equals direct quantization (none)', () => {
+    // No error diffused => each pixel quantizes against its raw value, exactly
+    // like the "none" path. Use a palette-aligned gradient to keep it exact.
+    const width = 8
+    const height = 4
+    const img = makeImage(width, height, (x) => {
+      const v = Math.round((x / (width - 1)) * 255)
+      return [v, 0, 0, 255]
+    })
+    const zero = applyEGXDitheringByMode(
+      img,
+      EGX1_PALETTE,
+      makeConfig(),
+      'floydSteinberg',
+      0
+    )
+    const none = applyEGXDitheringByMode(
+      img,
+      EGX1_PALETTE,
+      makeConfig(),
+      'none',
+      0
+    )
+    expect(Array.from(zero)).toEqual(Array.from(none))
+  })
+
+  it('respects firstLineMode "high" (even lines become high-res)', () => {
+    const config = makeConfig({ firstLineMode: 'high' })
+    // Yellow only available on Mode 0 (low-res) lines, which are now the odd ones.
+    const img = makeImage(4, 2, uniform(255, 255, 0))
+    const out = applyEGXDitheringByMode(img, EGX1_PALETTE, config, 'none', 1)
+
+    // y=0 is now Mode 1 (high-res) -> cannot be yellow (index 4).
+    const even: [number, number, number] = [out[0], out[1], out[2]]
+    expect(even).not.toEqual([255, 255, 0])
+    expectAllColorsInSubPalette(out, 4, 2, EGX1_PALETTE, config)
+  })
+
+  it('handles EGX2 (Mode 1 / Mode 2) sub-palette constraints', () => {
+    const width = 4
+    const height = 4
+    const config = makeConfig({ type: 'egx2' })
+    const img = makeImage(width, height, (x, y) => [
+      x * 80,
+      0,
+      (y % 2) * 200,
+      255
+    ])
+    for (const mode of ALL_MODES) {
+      const out = applyEGXDitheringByMode(img, EGX2_PALETTE, config, mode, 1)
+      expect(out.length).toBe(width * height * 4)
+      expectAllColorsInSubPalette(out, width, height, EGX2_PALETTE, config)
+    }
+  })
+
+  it('runs Ostromoukhov serpentine scan without NaN on a wide gradient', () => {
+    // Width > 1 and several lines exercises both serpentine directions.
+    const width = 9
+    const height = 5
+    const img = makeImage(width, height, (x, y) => [
+      (x * 28) % 256,
+      (y * 51) % 256,
+      ((x + y) * 33) % 256,
+      255
+    ])
+    const out = applyEGXDitheringByMode(
+      img,
+      EGX1_PALETTE,
+      makeConfig(),
+      'ostromoukhov',
+      1
+    )
+    for (let i = 0; i < out.length; i++) {
+      expect(Number.isFinite(out[i])).toBe(true)
+    }
+    expectAllColorsInSubPalette(out, width, height, EGX1_PALETTE, makeConfig())
+  })
+
+  it('honours useDiffusionCorrection toggle without crashing', () => {
+    const img = makeImage(6, 4, (x, y) => [(x * 40) % 256, y * 60, 100, 255])
+    const on = applyEGXDitheringByMode(
+      img,
+      EGX1_PALETTE,
+      makeConfig({ useDiffusionCorrection: true }),
+      'floydSteinberg',
+      1
+    )
+    const off = applyEGXDitheringByMode(
+      img,
+      EGX1_PALETTE,
+      makeConfig({ useDiffusionCorrection: false }),
+      'floydSteinberg',
+      1
+    )
+    expect(on.length).toBe(off.length)
+    expectAllColorsInSubPalette(on, 6, 4, EGX1_PALETTE, makeConfig())
+    expectAllColorsInSubPalette(off, 6, 4, EGX1_PALETTE, makeConfig())
+  })
+
+  it('honours useOrderedCorrection toggle for Bayer dithering', () => {
+    const img = makeImage(6, 4, (x, y) => [(x * 40) % 256, y * 60, 100, 255])
+    const on = applyEGXDitheringByMode(
+      img,
+      EGX1_PALETTE,
+      makeConfig({ useOrderedCorrection: true }),
+      'bayer4x4',
+      1
+    )
+    const off = applyEGXDitheringByMode(
+      img,
+      EGX1_PALETTE,
+      makeConfig({ useOrderedCorrection: false }),
+      'bayer4x4',
+      1
+    )
+    expect(on.length).toBe(off.length)
+    expectAllColorsInSubPalette(on, 6, 4, EGX1_PALETTE, makeConfig())
+    expectAllColorsInSubPalette(off, 6, 4, EGX1_PALETTE, makeConfig())
+  })
+})
+
+describe('re-exported colour utilities', () => {
+  it('colorDistanceSquared returns squared Euclidean RGB distance', () => {
+    expect(colorDistanceSquared([0, 0, 0], [0, 0, 0])).toBe(0)
+    expect(colorDistanceSquared([0, 0, 0], [1, 2, 2])).toBe(9)
+    expect(colorDistanceSquared([10, 0, 0], [0, 0, 0])).toBe(100)
+  })
+
+  it('findClosestInSubset only searches up to maxIndex (inclusive)', () => {
+    const palette: Vector<'RGB'>[] = [
+      [0, 0, 0],
+      [255, 255, 255],
+      [10, 10, 10]
+    ]
+    // Target is closest to index 2, but with maxIndex 1 it must pick index 0.
+    const limited = findClosestInSubset([12, 12, 12], palette, 1)
+    expect(limited.index).toBe(0)
+    expect(limited.color).toEqual([0, 0, 0])
+
+    // With the full subset it should reach the genuine closest (index 2).
+    const full = findClosestInSubset([12, 12, 12], palette, 2)
+    expect(full.index).toBe(2)
+    expect(full.color).toEqual([10, 10, 10])
+  })
+})

--- a/src/libs/pixsaur-egx/palette-optimizer.spec.ts
+++ b/src/libs/pixsaur-egx/palette-optimizer.spec.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from 'vitest'
+import type { Vector } from '@/libs/pixsaur-color/src/type'
+import { getHardwarePalette, optimizeEGXPalette } from './palette-optimizer'
+import type { EGXConfig } from './types'
+
+const baseConfig: EGXConfig = {
+  type: 'egx1',
+  firstLineMode: 'low',
+  targetHardware: 'classic',
+  ditheringMode: 'none',
+  ditheringIntensity: 0
+}
+
+/**
+ * Build an RGBA buffer (Uint8ClampedArray) of size width*height filled
+ * with a deterministic pattern: a handful of distinct, well-separated
+ * colors cycled across pixels so the histogram has clear winners.
+ */
+function buildImage(
+  width: number,
+  height: number,
+  colors: Vector<'RGB'>[]
+): Uint8ClampedArray {
+  const data = new Uint8ClampedArray(width * height * 4)
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = (y * width + x) * 4
+      const c = colors[(y * width + x) % colors.length]
+      data[idx] = c[0]
+      data[idx + 1] = c[1]
+      data[idx + 2] = c[2]
+      data[idx + 3] = 255
+    }
+  }
+  return data
+}
+
+function paletteContains(
+  palette: Vector<'RGB'>[],
+  color: Vector<'RGB'>
+): boolean {
+  return palette.some(
+    (p) => p[0] === color[0] && p[1] === color[1] && p[2] === color[2]
+  )
+}
+
+describe('getHardwarePalette', () => {
+  it('returns the 27-color CPC Classic palette', () => {
+    const palette = getHardwarePalette('classic')
+    expect(palette).toHaveLength(27)
+  })
+
+  it('builds the Classic palette from the 0/128/255 level cube', () => {
+    const palette = getHardwarePalette('classic')
+    const levels = new Set<number>()
+    for (const [r, g, b] of palette) {
+      levels.add(r)
+      levels.add(g)
+      levels.add(b)
+    }
+    expect([...levels].sort((a, b) => a - b)).toEqual([0, 128, 255])
+  })
+
+  it('orders Classic entries with black first and white last', () => {
+    const palette = getHardwarePalette('classic')
+    expect(palette[0]).toEqual([0, 0, 0])
+    expect(palette[palette.length - 1]).toEqual([255, 255, 255])
+  })
+
+  it('returns the 4096-color CPC Plus palette', () => {
+    const palette = getHardwarePalette('plus')
+    expect(palette).toHaveLength(4096)
+  })
+
+  it('builds Plus entries as multiples of 17 in 0..255', () => {
+    const palette = getHardwarePalette('plus')
+    expect(palette[0]).toEqual([0, 0, 0])
+    expect(palette[palette.length - 1]).toEqual([255, 255, 255])
+    for (const [r, g, b] of palette) {
+      for (const channel of [r, g, b]) {
+        expect(channel).toBeGreaterThanOrEqual(0)
+        expect(channel).toBeLessThanOrEqual(255)
+        expect(channel % 17).toBe(0)
+      }
+    }
+  })
+
+  it('keeps every channel within the 0..255 RGB range', () => {
+    for (const target of ['classic', 'plus'] as const) {
+      for (const [r, g, b] of getHardwarePalette(target)) {
+        for (const channel of [r, g, b]) {
+          expect(channel).toBeGreaterThanOrEqual(0)
+          expect(channel).toBeLessThanOrEqual(255)
+        }
+      }
+    }
+  })
+
+  it('produces unique colors', () => {
+    for (const target of ['classic', 'plus'] as const) {
+      const palette = getHardwarePalette(target)
+      const keys = new Set(palette.map((c) => c.join(',')))
+      expect(keys.size).toBe(palette.length)
+    }
+  })
+})
+
+describe('optimizeEGXPalette', () => {
+  const width = 8
+  const height = 8
+  // Pure primaries/black/white drawn from the Classic hardware set.
+  const sampleColors: Vector<'RGB'>[] = [
+    [255, 0, 0],
+    [0, 255, 0],
+    [0, 0, 255],
+    [255, 255, 0],
+    [0, 0, 0],
+    [255, 255, 255]
+  ]
+  // The full 27-color Classic set — guarantees enough distinct colors to
+  // fill all 16 EGX1 slots.
+  const richColors = getHardwarePalette('classic')
+
+  it('selects up to 16 colors with 4 shared colors for EGX1', () => {
+    const image = buildImage(width, height, richColors)
+    const result = optimizeEGXPalette(image, width, height, baseConfig)
+    expect(result.colors).toHaveLength(16)
+    expect(result.sharedColorCount).toBe(4)
+  })
+
+  it('never exceeds the EGX1 palette budget even with few colors', () => {
+    const image = buildImage(width, height, sampleColors)
+    const result = optimizeEGXPalette(image, width, height, baseConfig)
+    expect(result.colors.length).toBeLessThanOrEqual(16)
+    expect(result.colors.length).toBeGreaterThan(0)
+    expect(result.sharedColorCount).toBe(4)
+  })
+
+  it('returns a 4-color palette with 2 shared colors for EGX2', () => {
+    const image = buildImage(width, height, sampleColors)
+    const result = optimizeEGXPalette(image, width, height, {
+      ...baseConfig,
+      type: 'egx2'
+    })
+    expect(result.colors).toHaveLength(4)
+    expect(result.sharedColorCount).toBe(2)
+  })
+
+  it('only emits colors that belong to the hardware palette', () => {
+    const image = buildImage(width, height, sampleColors)
+    const hardware = getHardwarePalette('classic')
+    const result = optimizeEGXPalette(image, width, height, baseConfig)
+    for (const color of result.colors) {
+      expect(paletteContains(hardware, color)).toBe(true)
+    }
+  })
+
+  it('respects the Plus hardware target', () => {
+    const image = buildImage(width, height, richColors)
+    const hardware = getHardwarePalette('plus')
+    const result = optimizeEGXPalette(image, width, height, {
+      ...baseConfig,
+      targetHardware: 'plus'
+    })
+    expect(result.colors).toHaveLength(16)
+    for (const color of result.colors) {
+      expect(paletteContains(hardware, color)).toBe(true)
+    }
+  })
+
+  it('is deterministic for identical inputs', () => {
+    const imageA = buildImage(width, height, sampleColors)
+    const imageB = buildImage(width, height, sampleColors)
+    const a = optimizeEGXPalette(imageA, width, height, baseConfig)
+    const b = optimizeEGXPalette(imageB, width, height, baseConfig)
+    expect(b.colors).toEqual(a.colors)
+    expect(b.sharedColorCount).toBe(a.sharedColorCount)
+    expect(b.stats).toEqual(a.stats)
+  })
+
+  it('produces palette entries with valid RGB channels', () => {
+    const image = buildImage(width, height, sampleColors)
+    const result = optimizeEGXPalette(image, width, height, baseConfig)
+    for (const [r, g, b] of result.colors) {
+      for (const channel of [r, g, b]) {
+        expect(channel).toBeGreaterThanOrEqual(0)
+        expect(channel).toBeLessThanOrEqual(255)
+      }
+    }
+  })
+
+  it('reports non-negative stats consistent with the palette', () => {
+    const image = buildImage(width, height, sampleColors)
+    const result = optimizeEGXPalette(image, width, height, baseConfig)
+    const { stats } = result
+    expect(stats.colorsUsedLowMode).toBeGreaterThanOrEqual(0)
+    expect(stats.colorsUsedHighMode).toBeGreaterThanOrEqual(0)
+    expect(stats.avgErrorLowMode).toBeGreaterThanOrEqual(0)
+    expect(stats.avgErrorHighMode).toBeGreaterThanOrEqual(0)
+    // High-res lines are constrained to the shared slots, so they can never
+    // use more distinct colors than sharedColorCount.
+    expect(stats.colorsUsedHighMode).toBeLessThanOrEqual(
+      result.sharedColorCount
+    )
+    expect(stats.colorsUsedLowMode).toBeLessThanOrEqual(result.colors.length)
+    expect(stats.totalError).toBeGreaterThanOrEqual(0)
+    // totalError is the sum of the two per-mode error accumulators.
+    expect(stats.totalError).toBeCloseTo(
+      stats.avgErrorLowMode * (width * (height / 2)) +
+        stats.avgErrorHighMode * (width * (height / 2)),
+      4
+    )
+  })
+
+  it('yields zero average error when every source color is on the hardware set', () => {
+    // A single Classic color used everywhere must be representable exactly.
+    const image = buildImage(width, height, [[128, 0, 255]])
+    const result = optimizeEGXPalette(image, width, height, baseConfig)
+    expect(result.stats.avgErrorLowMode).toBeCloseTo(0, 5)
+    expect(result.stats.avgErrorHighMode).toBeCloseTo(0, 5)
+    expect(result.stats.totalError).toBeCloseTo(0, 5)
+  })
+
+  it('handles firstLineMode high without changing palette size', () => {
+    const image = buildImage(width, height, richColors)
+    const result = optimizeEGXPalette(image, width, height, {
+      ...baseConfig,
+      firstLineMode: 'high'
+    })
+    expect(result.colors).toHaveLength(16)
+    expect(result.sharedColorCount).toBe(4)
+  })
+})

--- a/src/libs/pixsaur-egx/palette-reorder.spec.ts
+++ b/src/libs/pixsaur-egx/palette-reorder.spec.ts
@@ -1,0 +1,422 @@
+import { describe, expect, it } from 'vitest'
+import type { Vector } from '../pixsaur-color/src/type'
+import {
+  analyzeHighResLineColors,
+  combinations,
+  optimizePaletteForEGX
+} from './palette-reorder'
+import type { EGXConfig } from './types'
+
+// Helper: materialise a generator into a plain array of arrays
+function toArray(gen: Generator<number[]>): number[][] {
+  return [...gen]
+}
+
+// Minimal valid EGX config with overridable fields
+function makeConfig(over: Partial<EGXConfig> = {}): EGXConfig {
+  return {
+    type: 'egx1',
+    firstLineMode: 'low',
+    targetHardware: 'classic',
+    ditheringMode: 'none',
+    ditheringIntensity: 0,
+    ...over
+  }
+}
+
+// Build an ImageData where every row is filled with one solid RGB color.
+// rowColors[y] is the [r,g,b] used for the whole of row y.
+function imageFromRowColors(
+  width: number,
+  rowColors: Vector<'RGB'>[]
+): ImageData {
+  const height = rowColors.length
+  const data = new Uint8ClampedArray(width * height * 4)
+  for (let y = 0; y < height; y++) {
+    const [r, g, b] = rowColors[y] as [number, number, number]
+    for (let x = 0; x < width; x++) {
+      const idx = (y * width + x) * 4
+      data[idx] = r
+      data[idx + 1] = g
+      data[idx + 2] = b
+      data[idx + 3] = 255
+    }
+  }
+  return new ImageData(data, width, height)
+}
+
+describe('combinations', () => {
+  it('yields all 2-combinations of [0,1,2] in lexicographic order', () => {
+    expect(toArray(combinations([0, 1, 2], 2))).toEqual([
+      [0, 1],
+      [0, 2],
+      [1, 2]
+    ])
+  })
+
+  it('yields all 2-combinations of [0,1,2,3]', () => {
+    expect(toArray(combinations([0, 1, 2, 3], 2))).toEqual([
+      [0, 1],
+      [0, 2],
+      [0, 3],
+      [1, 2],
+      [1, 3],
+      [2, 3]
+    ])
+  })
+
+  it('yields the element values, not indices, when arr is not 0..n', () => {
+    expect(toArray(combinations([10, 20, 30], 2))).toEqual([
+      [10, 20],
+      [10, 30],
+      [20, 30]
+    ])
+  })
+
+  it('produces C(n,k) combinations for several n,k', () => {
+    const cnk = (n: number, k: number): number => {
+      let num = 1
+      let den = 1
+      for (let i = 0; i < k; i++) {
+        num *= n - i
+        den *= i + 1
+      }
+      return num / den
+    }
+    for (const [n, k] of [
+      [5, 1],
+      [5, 2],
+      [5, 3],
+      [6, 3],
+      [7, 4]
+    ] as const) {
+      const arr = Array.from({ length: n }, (_, i) => i)
+      expect(toArray(combinations(arr, k)).length).toBe(cnk(n, k))
+    }
+  })
+
+  it('yields a single empty combination when k = 0', () => {
+    expect(toArray(combinations([0, 1, 2], 0))).toEqual([[]])
+  })
+
+  it('yields nothing when k > n', () => {
+    expect(toArray(combinations([0, 1], 5))).toEqual([])
+  })
+
+  it('yields one full combination when k === n', () => {
+    expect(toArray(combinations([0, 1, 2], 3))).toEqual([[0, 1, 2]])
+  })
+
+  it('yields nothing for k > n even with an empty array', () => {
+    expect(toArray(combinations([], 1))).toEqual([])
+  })
+
+  it('yields a single empty combination for empty array with k = 0', () => {
+    expect(toArray(combinations([], 0))).toEqual([[]])
+  })
+})
+
+describe('analyzeHighResLineColors', () => {
+  const palette: Vector<'RGB'>[] = [
+    [0, 0, 0], // index 0: black
+    [255, 0, 0], // index 1: red
+    [0, 255, 0], // index 2: green
+    [0, 0, 255] // index 3: blue
+  ]
+
+  it('initialises a usage count for every palette index', () => {
+    const image = imageFromRowColors(4, [[0, 0, 0]])
+    const usage = analyzeHighResLineColors(image, palette, makeConfig())
+    expect(usage.size).toBe(palette.length)
+    for (let i = 0; i < palette.length; i++) {
+      expect(usage.has(i)).toBe(true)
+    }
+  })
+
+  it('counts odd rows as high-res when firstLineMode is "low"', () => {
+    // 4 wide, rows: 0=black,1=red,2=green,3=blue
+    // firstLineMode 'low' -> high-res lines are odd rows (1 and 3)
+    const image = imageFromRowColors(4, [
+      [0, 0, 0],
+      [255, 0, 0],
+      [0, 255, 0],
+      [0, 0, 255]
+    ])
+    const usage = analyzeHighResLineColors(
+      image,
+      palette,
+      makeConfig({ firstLineMode: 'low' })
+    )
+    // Only rows 1 (red) and 3 (blue) counted, 4 px each
+    expect(usage.get(0)).toBe(0)
+    expect(usage.get(1)).toBe(4)
+    expect(usage.get(2)).toBe(0)
+    expect(usage.get(3)).toBe(4)
+  })
+
+  it('counts even rows as high-res when firstLineMode is "high"', () => {
+    const image = imageFromRowColors(4, [
+      [0, 0, 0],
+      [255, 0, 0],
+      [0, 255, 0],
+      [0, 0, 255]
+    ])
+    const usage = analyzeHighResLineColors(
+      image,
+      palette,
+      makeConfig({ firstLineMode: 'high' })
+    )
+    // Only rows 0 (black) and 2 (green) counted, 4 px each
+    expect(usage.get(0)).toBe(4)
+    expect(usage.get(1)).toBe(0)
+    expect(usage.get(2)).toBe(4)
+    expect(usage.get(3)).toBe(0)
+  })
+
+  it('maps each pixel to its nearest palette color', () => {
+    // A near-red pixel snaps to the red index, not exact match required
+    const image = imageFromRowColors(2, [
+      [0, 0, 0],
+      [250, 5, 5] // close to pure red index 1
+    ])
+    const usage = analyzeHighResLineColors(
+      image,
+      palette,
+      makeConfig({ firstLineMode: 'low' })
+    )
+    // Row 1 is high-res, 2 px both nearest to red
+    expect(usage.get(1)).toBe(2)
+    expect(usage.get(0)).toBe(0)
+  })
+
+  it('returns all-zero counts when there are no high-res lines', () => {
+    // Single even row, firstLineMode 'low' -> row 0 is low-res, skipped
+    const image = imageFromRowColors(4, [[255, 0, 0]])
+    const usage = analyzeHighResLineColors(
+      image,
+      palette,
+      makeConfig({ firstLineMode: 'low' })
+    )
+    for (let i = 0; i < palette.length; i++) {
+      expect(usage.get(i)).toBe(0)
+    }
+  })
+
+  it('total counted pixels equals (high-res line count) * width', () => {
+    const image = imageFromRowColors(3, [
+      [255, 0, 0],
+      [0, 255, 0],
+      [0, 0, 255],
+      [0, 0, 0]
+    ])
+    const usage = analyzeHighResLineColors(
+      image,
+      palette,
+      makeConfig({ firstLineMode: 'low' })
+    )
+    // high-res rows are odd: rows 1 and 3 => 2 lines * width 3 = 6
+    let total = 0
+    for (const v of usage.values()) total += v
+    expect(total).toBe(6)
+  })
+})
+
+describe('optimizePaletteForEGX', () => {
+  const palette: Vector<'RGB'>[] = [
+    [0, 0, 0], // 0
+    [255, 0, 0], // 1
+    [0, 255, 0], // 2
+    [0, 0, 255], // 3
+    [255, 255, 0] // 4
+  ]
+
+  it('returns a palette of the same length as the input', () => {
+    const usage = new Map<number, number>([
+      [0, 10],
+      [1, 5],
+      [2, 3],
+      [3, 1],
+      [4, 0]
+    ])
+    const result = optimizePaletteForEGX(palette, usage, 2, false)
+    expect(result.length).toBe(palette.length)
+  })
+
+  it('every output color comes from the input palette (classic)', () => {
+    const usage = new Map<number, number>([
+      [0, 10],
+      [1, 5],
+      [2, 3],
+      [3, 1],
+      [4, 0]
+    ])
+    const result = optimizePaletteForEGX(palette, usage, 2, false)
+    const inputSet = new Set(palette.map((c) => (c as number[]).join(',')))
+    for (const c of result) {
+      expect(inputSet.has((c as number[]).join(','))).toBe(true)
+    }
+  })
+
+  it('selects the shared slots by maximising 0.7*coverage + 0.3*contrast (classic)', () => {
+    // Classic (isPlus=false) has no distance constraint, so the best combo is
+    // the one with the maximum score over all C(n,sharedCount) pairs. We
+    // compute that winner independently here from the same formula the source
+    // uses, then assert the optimizer's shared slots match it exactly.
+    const usage = new Map<number, number>([
+      [0, 1],
+      [1, 100],
+      [2, 90],
+      [3, 2],
+      [4, 1]
+    ])
+    const sharedCount = 2
+
+    const distSq = (a: Vector<'RGB'>, b: Vector<'RGB'>): number => {
+      const av = a as number[]
+      const bv = b as number[]
+      const dr = av[0] - bv[0]
+      const dg = av[1] - bv[1]
+      const db = av[2] - bv[2]
+      return dr * dr + dg * dg + db * db
+    }
+
+    // top indices = max(8, sharedCount) most used => all 5 here (sorted desc)
+    const sortedIndices = [...usage.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([idx]) => idx)
+    const topIndices = sortedIndices.slice(0, Math.max(8, sharedCount))
+
+    let bestScore = -Infinity
+    let expectedCombo: number[] = []
+    for (const combo of combinations(topIndices, sharedCount)) {
+      let coverage = 0
+      for (const idx of combo) coverage += usage.get(idx) ?? 0
+      let contrast = 0
+      let pairs = 0
+      for (let i = 0; i < combo.length; i++) {
+        for (let j = i + 1; j < combo.length; j++) {
+          contrast += distSq(palette[combo[i]], palette[combo[j]])
+          pairs++
+        }
+      }
+      contrast = pairs > 0 ? contrast / pairs : 0
+      const score = 0.7 * coverage + 0.3 * contrast
+      if (score > bestScore) {
+        bestScore = score
+        expectedCombo = combo
+      }
+    }
+
+    const result = optimizePaletteForEGX(palette, usage, sharedCount, false)
+    const shared = result
+      .slice(0, sharedCount)
+      .map((c) => (c as number[]).join(','))
+    const expectedShared = expectedCombo.map((idx) => palette[idx].join(','))
+    expect(shared).toEqual(expectedShared)
+  })
+
+  it('is deterministic across repeated calls with identical input', () => {
+    const usage = new Map<number, number>([
+      [0, 7],
+      [1, 6],
+      [2, 5],
+      [3, 4],
+      [4, 3]
+    ])
+    const a = optimizePaletteForEGX(palette, usage, 2, false)
+    const b = optimizePaletteForEGX(palette, usage, 2, false)
+    expect(a).toEqual(b)
+  })
+
+  it('pads with black when sharedCount cannot be satisfied from usage', () => {
+    // Usage only references index 0; topIndices has a single entry so the
+    // shared slot selection cannot fill sharedCount=2, and the tail is
+    // padded with black to reach palette length.
+    const smallPalette: Vector<'RGB'>[] = [
+      [12, 34, 56],
+      [78, 90, 11]
+    ]
+    const usage = new Map<number, number>([[0, 5]])
+    const result = optimizePaletteForEGX(smallPalette, usage, 2, false)
+    expect(result.length).toBe(smallPalette.length)
+    // Last slot is padded black since only one index was known
+    expect(result[result.length - 1]).toEqual([0, 0, 0])
+  })
+
+  it('keeps all distinct input colors present when usage covers them all', () => {
+    const usage = new Map<number, number>([
+      [0, 5],
+      [1, 4],
+      [2, 3],
+      [3, 2],
+      [4, 1]
+    ])
+    const result = optimizePaletteForEGX(palette, usage, 2, false)
+    const resultSet = new Set(result.map((c) => (c as number[]).join(',')))
+    for (const c of palette) {
+      expect(resultSet.has((c as number[]).join(','))).toBe(true)
+    }
+  })
+
+  it('rejects perceptually too-close colors from shared slots on Plus', () => {
+    // On Plus (isPlus=true) shared colors must be >= 100 RGB units apart.
+    // Index 0 and 1 are near-identical greys; index 0 is most used, so the
+    // optimizer must skip 1 for the second shared slot and pick a distant one.
+    const plusPalette: Vector<'RGB'>[] = [
+      [10, 10, 10], // 0: very dark grey (most used)
+      [20, 20, 20], // 1: near-identical dark grey
+      [255, 255, 255], // 2: white, far from the greys
+      [255, 0, 0] // 3: red, also far
+    ]
+    const usage = new Map<number, number>([
+      [0, 100],
+      [1, 90],
+      [2, 5],
+      [3, 4]
+    ])
+    const result = optimizePaletteForEGX(plusPalette, usage, 2, true)
+    const shared = result.slice(0, 2).map((c) => (c as number[]).join(','))
+    // Slot 0 keeps the most-used dark grey, but slot 1 cannot be the
+    // near-identical grey (too close on Plus).
+    expect(shared).toContain(plusPalette[0].join(','))
+    expect(shared).not.toContain(plusPalette[1].join(','))
+  })
+
+  it('falls back to most-used colors when no valid Plus combination exists', () => {
+    // Every color is within the Plus minimum distance of every other, so no
+    // combination of 2 is valid; selectFallbackColors then fills the shared
+    // slots with the most-used colors regardless of the distance constraint.
+    const clusteredPalette: Vector<'RGB'>[] = [
+      [10, 10, 10],
+      [15, 15, 15],
+      [20, 20, 20],
+      [25, 25, 25]
+    ]
+    const usage = new Map<number, number>([
+      [0, 40],
+      [1, 30],
+      [2, 20],
+      [3, 10]
+    ])
+    const result = optimizePaletteForEGX(clusteredPalette, usage, 2, true)
+    expect(result.length).toBe(clusteredPalette.length)
+    // Fallback keeps the two most-used colors and every input color survives
+    const resultSet = new Set(result.map((c) => (c as number[]).join(',')))
+    for (const c of clusteredPalette) {
+      expect(resultSet.has((c as number[]).join(','))).toBe(true)
+    }
+  })
+
+  it('defaults isPlus to false when omitted', () => {
+    const usage = new Map<number, number>([
+      [0, 5],
+      [1, 4],
+      [2, 3],
+      [3, 2],
+      [4, 1]
+    ])
+    const withDefault = optimizePaletteForEGX(palette, usage, 2)
+    const explicit = optimizePaletteForEGX(palette, usage, 2, false)
+    expect(withDefault).toEqual(explicit)
+  })
+})

--- a/src/libs/pixsaur-egx/quantize-egx.spec.ts
+++ b/src/libs/pixsaur-egx/quantize-egx.spec.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it } from 'vitest'
+import {
+  generateEGXPreview,
+  generateEGXPreviewMode0,
+  quantizeEGX
+} from './quantize-egx'
+import type { EGXConfig } from './types'
+import {
+  getEGXOutputDimensions,
+  getMaxColorIndex,
+  getModeForLine
+} from './types'
+
+type RGBA = [number, number, number, number]
+
+/** Build a flat RGBA buffer of `width`×`height`, each pixel from `fill(x, y)`. */
+function makeBuffer(
+  width: number,
+  height: number,
+  fill: (x: number, y: number) => RGBA
+): Uint8ClampedArray {
+  const data = new Uint8ClampedArray(width * height * 4)
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const [r, g, b, a] = fill(x, y)
+      const idx = (y * width + x) * 4
+      data[idx] = r
+      data[idx + 1] = g
+      data[idx + 2] = b
+      data[idx + 3] = a
+    }
+  }
+  return data
+}
+
+const uniform =
+  (r: number, g: number, b: number, a = 255) =>
+  (): RGBA => [r, g, b, a]
+
+/** Minimal valid EGX1 config (Mode 0 / Mode 1 alternation). */
+const egx1Config: EGXConfig = {
+  type: 'egx1',
+  firstLineMode: 'low',
+  targetHardware: 'classic',
+  ditheringMode: 'none',
+  ditheringIntensity: 0
+}
+
+/** Minimal valid EGX2 config (Mode 1 / Mode 2 alternation). */
+const egx2Config: EGXConfig = {
+  type: 'egx2',
+  firstLineMode: 'low',
+  targetHardware: 'classic',
+  ditheringMode: 'none',
+  ditheringIntensity: 0
+}
+
+/** Euclidean-squared distance between two RGB triples. */
+function dist2(
+  a: readonly number[],
+  b: readonly [number, number, number]
+): number {
+  const dr = a[0] - b[0]
+  const dg = a[1] - b[1]
+  const db = a[2] - b[2]
+  return dr * dr + dg * dg + db * db
+}
+
+describe('quantizeEGX', () => {
+  it('produces the EGX1 output dimensions regardless of input size', () => {
+    const input = makeBuffer(4, 2, uniform(100, 100, 100))
+    const result = quantizeEGX(input, 4, 2, egx1Config)
+    const dims = getEGXOutputDimensions('egx1')
+    expect(result.width).toBe(dims.width)
+    expect(result.height).toBe(dims.height)
+    expect(result.indexBuffer.length).toBe(dims.width * dims.height)
+  })
+
+  it('produces the EGX2 output dimensions regardless of input size', () => {
+    const input = makeBuffer(4, 2, uniform(50, 60, 70))
+    const result = quantizeEGX(input, 4, 2, egx2Config)
+    const dims = getEGXOutputDimensions('egx2')
+    expect(result.width).toBe(dims.width)
+    expect(result.height).toBe(dims.height)
+    expect(result.indexBuffer.length).toBe(dims.width * dims.height)
+  })
+
+  it('emits one line encoding per output line', () => {
+    const input = makeBuffer(4, 2, uniform(10, 20, 30))
+    const result = quantizeEGX(input, 4, 2, egx1Config)
+    expect(result.lineEncodings).toHaveLength(result.height)
+    result.lineEncodings.forEach((enc, y) => {
+      expect(enc.line).toBe(y)
+      expect(enc.mode).toBe(getModeForLine(y, egx1Config))
+    })
+  })
+
+  it('keeps every index within its line max color index (EGX1)', () => {
+    // Multi-colour input so high-res lines are genuinely constrained.
+    const input = makeBuffer(4, 4, (x, y) => [
+      (x * 60) % 256,
+      (y * 60) % 256,
+      ((x + y) * 40) % 256,
+      255
+    ])
+    const result = quantizeEGX(input, 4, 4, egx1Config)
+    for (let y = 0; y < result.height; y++) {
+      const mode = getModeForLine(y, egx1Config)
+      const maxIndex = getMaxColorIndex(mode, 'egx1')
+      for (let x = 0; x < result.width; x++) {
+        const idx = result.indexBuffer[y * result.width + x]
+        expect(idx).toBeGreaterThanOrEqual(0)
+        expect(idx).toBeLessThanOrEqual(maxIndex)
+        expect(idx).toBeLessThan(result.palette.colors.length)
+      }
+    }
+  })
+
+  it('keeps high-res lines within INK 0-1 for EGX2', () => {
+    const input = makeBuffer(4, 4, (x, y) => [
+      (x * 50) % 256,
+      (y * 70) % 256,
+      90,
+      255
+    ])
+    const result = quantizeEGX(input, 4, 4, egx2Config)
+    for (let y = 0; y < result.height; y++) {
+      const mode = getModeForLine(y, egx2Config)
+      const maxIndex = getMaxColorIndex(mode, 'egx2')
+      for (let x = 0; x < result.width; x++) {
+        const idx = result.indexBuffer[y * result.width + x]
+        expect(idx).toBeLessThanOrEqual(maxIndex)
+      }
+    }
+  })
+
+  it('maps a uniform image to the single nearest palette color', () => {
+    const input = makeBuffer(4, 2, uniform(0, 0, 0))
+    const result = quantizeEGX(input, 4, 2, egx1Config)
+    // Every pixel should pick the palette entry closest to pure black.
+    // INK 0-3 are the shared colors usable by all lines, so verify each
+    // chosen index is the nearest available for its line's subset.
+    const black: [number, number, number] = [0, 0, 0]
+    for (let y = 0; y < result.height; y++) {
+      const mode = getModeForLine(y, egx1Config)
+      const maxIndex = getMaxColorIndex(mode, 'egx1')
+      // findClosestInSubset scans indices 0..min(maxIndex, len-1).
+      const limit = Math.min(maxIndex, result.palette.colors.length - 1)
+      let best = 0
+      let bestDist = Number.POSITIVE_INFINITY
+      for (let i = 0; i <= limit; i++) {
+        const d = dist2(Array.from(result.palette.colors[i]), black)
+        if (d < bestDist) {
+          bestDist = d
+          best = i
+        }
+      }
+      for (let x = 0; x < result.width; x++) {
+        expect(result.indexBuffer[y * result.width + x]).toBe(best)
+      }
+    }
+  })
+
+  it('reports a non-negative finite total error', () => {
+    const input = makeBuffer(4, 2, uniform(123, 45, 200))
+    const result = quantizeEGX(input, 4, 2, egx1Config)
+    expect(Number.isFinite(result.totalError)).toBe(true)
+    expect(result.totalError).toBeGreaterThanOrEqual(0)
+  })
+
+  it('respects firstLineMode by swapping line 0 mode', () => {
+    const input = makeBuffer(4, 2, uniform(80, 80, 80))
+    const low = quantizeEGX(input, 4, 2, {
+      ...egx1Config,
+      firstLineMode: 'low'
+    })
+    const high = quantizeEGX(input, 4, 2, {
+      ...egx1Config,
+      firstLineMode: 'high'
+    })
+    // EGX1: low->Mode0 first, high->Mode1 first.
+    expect(low.lineEncodings[0].mode).toBe(0)
+    expect(high.lineEncodings[0].mode).toBe(1)
+  })
+
+  it('does not resize when input already matches output dimensions', () => {
+    const dims = getEGXOutputDimensions('egx1')
+    const input = makeBuffer(dims.width, dims.height, uniform(255, 255, 255))
+    const result = quantizeEGX(input, dims.width, dims.height, egx1Config)
+    expect(result.width).toBe(dims.width)
+    expect(result.height).toBe(dims.height)
+    expect(result.indexBuffer.length).toBe(dims.width * dims.height)
+  })
+})
+
+describe('generateEGXPreview', () => {
+  it('returns an RGBA buffer matching the result dimensions', () => {
+    const input = makeBuffer(4, 2, uniform(120, 60, 30))
+    const result = quantizeEGX(input, 4, 2, egx1Config)
+    const preview = generateEGXPreview(result)
+    expect(preview.length).toBe(result.width * result.height * 4)
+    expect(preview).toBeInstanceOf(Uint8ClampedArray)
+  })
+
+  it('fills the combined preview with palette colors and opaque alpha', () => {
+    const input = makeBuffer(4, 2, uniform(0, 0, 0))
+    const result = quantizeEGX(input, 4, 2, egx1Config)
+    const preview = generateEGXPreview(result, 'combined')
+    for (let i = 0; i < preview.length; i += 4) {
+      expect(preview[i + 3]).toBe(255)
+      expect(Number.isNaN(preview[i])).toBe(false)
+      const idx = i / 4
+      const color = result.palette.colors[result.indexBuffer[idx]]
+      expect(preview[i]).toBe(color[0])
+      expect(preview[i + 1]).toBe(color[1])
+      expect(preview[i + 2]).toBe(color[2])
+    }
+  })
+
+  it('paints mode-map lines with distinct colors per line type', () => {
+    const input = makeBuffer(4, 2, uniform(50, 50, 50))
+    const result = quantizeEGX(input, 4, 2, egx1Config)
+    const preview = generateEGXPreview(result, 'modeMap')
+    const width = result.width
+    // Line 0 (low) -> orange-ish, line 1 (high) -> blue-ish.
+    const low = [preview[0], preview[1], preview[2]]
+    const highBase = (1 * width + 0) * 4
+    const high = [
+      preview[highBase],
+      preview[highBase + 1],
+      preview[highBase + 2]
+    ]
+    expect(low).toEqual([200, 120, 50])
+    expect(high).toEqual([50, 100, 200])
+    expect(low).not.toEqual(high)
+  })
+
+  it('grays out non-high lines in highLines mode', () => {
+    const input = makeBuffer(4, 2, uniform(0, 0, 0))
+    const result = quantizeEGX(input, 4, 2, egx1Config)
+    const preview = generateEGXPreview(result, 'highLines')
+    const width = result.width
+    // Line 0 is a low (Mode 0) line -> grayed out.
+    expect([preview[0], preview[1], preview[2]]).toEqual([128, 128, 128])
+    // Line 1 is a high (Mode 1) line -> real palette color, not gray gray.
+    const highIdx = (1 * width + 0) * 4
+    const color = result.palette.colors[result.indexBuffer[1 * width]]
+    expect(preview[highIdx]).toBe(color[0])
+    expect(preview[highIdx + 1]).toBe(color[1])
+    expect(preview[highIdx + 2]).toBe(color[2])
+  })
+
+  it('grays out high lines in lowLines mode', () => {
+    const input = makeBuffer(4, 2, uniform(0, 0, 0))
+    const result = quantizeEGX(input, 4, 2, egx1Config)
+    const preview = generateEGXPreview(result, 'lowLines')
+    const width = result.width
+    // Line 1 (high) is grayed out.
+    const highIdx = (1 * width + 0) * 4
+    expect([
+      preview[highIdx],
+      preview[highIdx + 1],
+      preview[highIdx + 2]
+    ]).toEqual([128, 128, 128])
+  })
+
+  it('never emits NaN or undefined samples', () => {
+    const input = makeBuffer(4, 4, (x, y) => [
+      (x * 40) % 256,
+      (y * 40) % 256,
+      80,
+      255
+    ])
+    const result = quantizeEGX(input, 4, 4, egx1Config)
+    const preview = generateEGXPreview(result)
+    for (let i = 0; i < preview.length; i++) {
+      expect(preview[i]).not.toBeUndefined()
+      expect(Number.isNaN(preview[i])).toBe(false)
+    }
+  })
+})
+
+describe('generateEGXPreviewMode0', () => {
+  it('halves the width and keeps the height', () => {
+    const input = makeBuffer(4, 2, uniform(90, 90, 90))
+    const result = quantizeEGX(input, 4, 2, egx1Config)
+    const preview = generateEGXPreviewMode0(result)
+    const outWidth = Math.floor(result.width / 2)
+    expect(preview.length).toBe(outWidth * result.height * 4)
+  })
+
+  it('takes every other pixel on Mode 0 lines', () => {
+    const input = makeBuffer(4, 2, uniform(0, 0, 0))
+    const result = quantizeEGX(input, 4, 2, egx1Config)
+    const preview = generateEGXPreviewMode0(result)
+    const fullWidth = result.width
+    const outWidth = Math.floor(fullWidth / 2)
+    // Line 0 is Mode 0: output x maps to source x*2 directly.
+    for (let x = 0; x < outWidth; x++) {
+      const outIdx = x * 4
+      const srcColorIdx = result.indexBuffer[0 * fullWidth + x * 2]
+      const color = result.palette.colors[srcColorIdx]
+      expect(preview[outIdx]).toBe(color[0])
+      expect(preview[outIdx + 1]).toBe(color[1])
+      expect(preview[outIdx + 2]).toBe(color[2])
+      expect(preview[outIdx + 3]).toBe(255)
+    }
+  })
+
+  it('averages two adjacent pixels on Mode 1 lines', () => {
+    const input = makeBuffer(4, 4, (x, y) => [
+      (x * 50) % 256,
+      (y * 50) % 256,
+      100,
+      255
+    ])
+    const result = quantizeEGX(input, 4, 4, egx1Config)
+    const preview = generateEGXPreviewMode0(result)
+    const fullWidth = result.width
+    const outWidth = Math.floor(fullWidth / 2)
+    // Line 1 is Mode 1 (high-res) -> averaged pair.
+    const y = 1
+    for (let x = 0; x < outWidth; x++) {
+      const outIdx = (y * outWidth + x) * 4
+      const c1 =
+        result.palette.colors[result.indexBuffer[y * fullWidth + x * 2]]
+      const c2 =
+        result.palette.colors[result.indexBuffer[y * fullWidth + x * 2 + 1]]
+      expect(preview[outIdx]).toBe(Math.round((c1[0] + c2[0]) / 2))
+      expect(preview[outIdx + 1]).toBe(Math.round((c1[1] + c2[1]) / 2))
+      expect(preview[outIdx + 2]).toBe(Math.round((c1[2] + c2[2]) / 2))
+    }
+  })
+
+  it('emits opaque, finite samples only', () => {
+    const input = makeBuffer(4, 4, (x, y) => [x * 30, y * 30, 60, 255])
+    const result = quantizeEGX(input, 4, 4, egx1Config)
+    const preview = generateEGXPreviewMode0(result)
+    for (let i = 0; i < preview.length; i += 4) {
+      expect(preview[i + 3]).toBe(255)
+      expect(Number.isNaN(preview[i])).toBe(false)
+    }
+  })
+
+  it('differs from the full-width combined preview width', () => {
+    const input = makeBuffer(4, 2, uniform(200, 100, 50))
+    const result = quantizeEGX(input, 4, 2, egx1Config)
+    const full = generateEGXPreview(result, 'combined')
+    const mode0 = generateEGXPreviewMode0(result)
+    expect(mode0.length).toBeLessThan(full.length)
+  })
+})

--- a/src/libs/pixsaur-mode-r/pair-optimizer.spec.ts
+++ b/src/libs/pixsaur-mode-r/pair-optimizer.spec.ts
@@ -1,0 +1,392 @@
+import { describe, expect, it } from 'vitest'
+import type { Vector } from '../pixsaur-color/src/type'
+import { blendColors, calculateFlickerScore } from './blend'
+import {
+  findNearestColor,
+  generateCPCClassicPalette,
+  generateCPCPlusPalette,
+  optimizeModeRPalettes
+} from './pair-optimizer'
+import type { ModeRConfig } from './types'
+import { DEFAULT_MODE_R_CONFIG } from './types'
+
+const key = (c: Vector<'RGB'>): string => `${c[0]},${c[1]},${c[2]}`
+
+describe('generateCPCClassicPalette', () => {
+  it('produces exactly 27 colors (3 levels per channel)', () => {
+    expect(generateCPCClassicPalette()).toHaveLength(27)
+  })
+
+  it('only uses the levels 0, 128 and 255 on every channel', () => {
+    const levels = new Set([0, 128, 255])
+    for (const color of generateCPCClassicPalette()) {
+      expect(levels.has(color[0])).toBe(true)
+      expect(levels.has(color[1])).toBe(true)
+      expect(levels.has(color[2])).toBe(true)
+    }
+  })
+
+  it('contains pure black and pure white', () => {
+    const keys = new Set(generateCPCClassicPalette().map(key))
+    expect(keys.has('0,0,0')).toBe(true)
+    expect(keys.has('255,255,255')).toBe(true)
+  })
+
+  it('has no duplicate colors', () => {
+    const palette = generateCPCClassicPalette()
+    expect(new Set(palette.map(key)).size).toBe(palette.length)
+  })
+})
+
+describe('generateCPCPlusPalette', () => {
+  it('produces exactly 4096 colors (16 levels per channel)', () => {
+    expect(generateCPCPlusPalette()).toHaveLength(4096)
+  })
+
+  it('quantizes every channel to a multiple of 17 within 0-255', () => {
+    for (const color of generateCPCPlusPalette()) {
+      for (const channel of color) {
+        expect(channel % 17).toBe(0)
+        expect(channel).toBeGreaterThanOrEqual(0)
+        expect(channel).toBeLessThanOrEqual(255)
+      }
+    }
+  })
+
+  it('contains pure black and pure white', () => {
+    const keys = new Set(generateCPCPlusPalette().map(key))
+    expect(keys.has('0,0,0')).toBe(true)
+    expect(keys.has('255,255,255')).toBe(true)
+  })
+
+  it('has no duplicate colors', () => {
+    const palette = generateCPCPlusPalette()
+    expect(new Set(palette.map(key)).size).toBe(palette.length)
+  })
+})
+
+describe('findNearestColor', () => {
+  it('returns an exact match when the target exists in the set', () => {
+    const available: Vector<'RGB'>[] = [
+      [0, 0, 0],
+      [255, 0, 0],
+      [0, 255, 0]
+    ]
+    expect(findNearestColor([0, 255, 0], available)).toEqual([0, 255, 0])
+  })
+
+  it('returns the only available color for a singleton set', () => {
+    const available: Vector<'RGB'>[] = [[10, 20, 30]]
+    expect(findNearestColor([200, 200, 200], available)).toEqual([10, 20, 30])
+  })
+
+  it('picks the perceptually closest color (green weighted higher)', () => {
+    // Target is a mid green. The weighted distance metric (BT.601) weights
+    // green at 0.587, so the green-leaning candidate wins clearly.
+    const available: Vector<'RGB'>[] = [
+      [255, 0, 0],
+      [0, 130, 0],
+      [0, 0, 255]
+    ]
+    expect(findNearestColor([0, 128, 0], available)).toEqual([0, 130, 0])
+  })
+
+  it('keeps the first candidate on a tie (no later replacement)', () => {
+    // Two candidates equidistant from the target: the earlier one is kept
+    // because the loop only replaces on strictly smaller distance.
+    const available: Vector<'RGB'>[] = [
+      [100, 100, 100],
+      [110, 110, 110]
+    ]
+    expect(findNearestColor([105, 105, 105], available)).toEqual([
+      100, 100, 100
+    ])
+  })
+})
+
+const baseConfig = (overrides: Partial<ModeRConfig> = {}): ModeRConfig => ({
+  ...DEFAULT_MODE_R_CONFIG,
+  ...overrides
+})
+
+describe('optimizeModeRPalettes', () => {
+  const targets: Vector<'RGB'>[] = [
+    [255, 0, 0],
+    [0, 255, 0],
+    [0, 0, 255],
+    [255, 255, 0],
+    [255, 255, 255],
+    [0, 0, 0]
+  ]
+
+  it('always returns two palettes of exactly 16 colors each', () => {
+    const { paletteA, paletteB } = optimizeModeRPalettes(
+      targets,
+      undefined,
+      baseConfig({ targetHardware: 'plus', useDualPalette: true })
+    )
+    expect(paletteA).toHaveLength(16)
+    expect(paletteB).toHaveLength(16)
+  })
+
+  it('returns exactly 16 pairs with consistent indices', () => {
+    const { pairs } = optimizeModeRPalettes(targets, undefined, baseConfig())
+    expect(pairs).toHaveLength(16)
+    pairs.forEach((pair, i) => {
+      expect(pair.index).toBe(i)
+    })
+  })
+
+  it('derives each pair blend and flicker from its A/B colors', () => {
+    const { paletteA, paletteB, pairs } = optimizeModeRPalettes(
+      targets,
+      undefined,
+      baseConfig({ useDualPalette: true })
+    )
+    pairs.forEach((pair, i) => {
+      expect(pair.colorA).toEqual(paletteA[i])
+      expect(pair.colorB).toEqual(paletteB[i])
+      expect(pair.blendedColor).toEqual(blendColors(paletteA[i], paletteB[i]))
+      expect(pair.flickerScore).toBe(
+        calculateFlickerScore(paletteA[i], paletteB[i])
+      )
+    })
+  })
+
+  it('uses the same palette for both frames in single-palette mode', () => {
+    const { paletteA, paletteB } = optimizeModeRPalettes(
+      targets,
+      undefined,
+      baseConfig({ useDualPalette: false })
+    )
+    expect(paletteB).toEqual(paletteA)
+  })
+
+  it('every diagonal pair has zero flicker in single-palette mode', () => {
+    // pairs[i] is (A[i], B[i]) and B === A, so the diagonal never flickers.
+    // (stats.maxFlicker covers the full 16x16 matrix, including off-diagonal
+    // A[i]/A[j] pairs which CAN flicker, so it is not asserted here.)
+    const { pairs } = optimizeModeRPalettes(
+      targets,
+      undefined,
+      baseConfig({ useDualPalette: false })
+    )
+    for (const pair of pairs) {
+      expect(pair.flickerScore).toBe(0)
+    }
+  })
+
+  it('emits only hardware-valid colors for CPC Classic (levels 0/128/255)', () => {
+    const { paletteA, paletteB } = optimizeModeRPalettes(
+      targets,
+      undefined,
+      baseConfig({ targetHardware: 'classic', useDualPalette: true })
+    )
+    const levels = new Set([0, 128, 255])
+    for (const color of [...paletteA, ...paletteB]) {
+      // Padding black [0,0,0] is also valid here.
+      expect(levels.has(color[0])).toBe(true)
+      expect(levels.has(color[1])).toBe(true)
+      expect(levels.has(color[2])).toBe(true)
+    }
+  })
+
+  it('emits only multiples of 17 for CPC Plus', () => {
+    const { paletteA, paletteB } = optimizeModeRPalettes(
+      targets,
+      undefined,
+      baseConfig({ targetHardware: 'plus', useDualPalette: true })
+    )
+    for (const color of [...paletteA, ...paletteB]) {
+      for (const channel of color) {
+        expect(channel % 17).toBe(0)
+      }
+    }
+  })
+
+  it('guarantees black is present in both palettes for margin handling', () => {
+    const hasBlack = (palette: Vector<'RGB'>[]): boolean =>
+      palette.some((c) => c[0] <= 17 && c[1] <= 17 && c[2] <= 17)
+    const { paletteA, paletteB } = optimizeModeRPalettes(
+      targets,
+      undefined,
+      baseConfig({ targetHardware: 'plus', useDualPalette: true })
+    )
+    expect(hasBlack(paletteA)).toBe(true)
+    expect(hasBlack(paletteB)).toBe(true)
+  })
+
+  it('handles an empty target list without throwing and still pads to 16', () => {
+    const { paletteA, paletteB, pairs } = optimizeModeRPalettes(
+      [],
+      undefined,
+      baseConfig({ useDualPalette: true })
+    )
+    expect(paletteA).toHaveLength(16)
+    expect(paletteB).toHaveLength(16)
+    expect(pairs).toHaveLength(16)
+  })
+
+  it('falls back to uniform weights when weights mismatch target length', () => {
+    // A wrong-length weights array must not throw; uniform weights kick in.
+    const wrongWeights = [1, 2]
+    const result = optimizeModeRPalettes(
+      targets,
+      wrongWeights,
+      baseConfig({ useDualPalette: true })
+    )
+    expect(result.paletteA).toHaveLength(16)
+    expect(result.paletteB).toHaveLength(16)
+  })
+
+  it('produces stats consistent with the full 16x16 blend matrix', () => {
+    const { paletteA, paletteB, stats } = optimizeModeRPalettes(
+      targets,
+      undefined,
+      baseConfig({ useDualPalette: true })
+    )
+
+    const uniqueBlends = new Set<string>()
+    let maxFlicker = 0
+    let noFlicker = 0
+    for (const a of paletteA) {
+      for (const b of paletteB) {
+        const blended = blendColors(a, b)
+        uniqueBlends.add(key(blended))
+        const flicker = calculateFlickerScore(a, b)
+        if (flicker > maxFlicker) maxFlicker = flicker
+        if (
+          flicker <= DEFAULT_MODE_R_CONFIG.maxLuminanceDelta &&
+          flicker === 0
+        ) {
+          noFlicker++
+        }
+      }
+    }
+
+    expect(stats.uniquePerceivedColors).toBe(uniqueBlends.size)
+    expect(stats.maxFlicker).toBe(maxFlicker)
+    expect(stats.noFlickerPairs).toBe(noFlicker)
+    expect(stats.uniquePerceivedColors).toBeGreaterThan(0)
+    expect(stats.uniquePerceivedColors).toBeLessThanOrEqual(256)
+  })
+
+  it('reports non-negative averageFlicker within maxFlicker bound', () => {
+    const { stats } = optimizeModeRPalettes(
+      targets,
+      undefined,
+      baseConfig({ useDualPalette: true })
+    )
+    expect(stats.averageFlicker).toBeGreaterThanOrEqual(0)
+    expect(stats.averageFlicker).toBeLessThanOrEqual(stats.maxFlicker)
+  })
+
+  it('single-palette mode still averages over within-tolerance pairs (incl. off-diagonal)', () => {
+    // averageFlicker is computed over ALL pairs within maxLuminanceDelta, which
+    // includes off-diagonal A[i]/A[j] pairs, so it is non-negative and bounded
+    // by maxFlicker rather than necessarily zero.
+    const { stats } = optimizeModeRPalettes(
+      targets,
+      undefined,
+      baseConfig({ useDualPalette: false })
+    )
+    expect(stats.averageFlicker).toBeGreaterThanOrEqual(0)
+    expect(stats.averageFlicker).toBeLessThanOrEqual(stats.maxFlicker)
+  })
+
+  it('single-palette mode counts at least 16 no-flicker pairs (the diagonal)', () => {
+    const { stats } = optimizeModeRPalettes(
+      targets,
+      undefined,
+      baseConfig({ useDualPalette: false })
+    )
+    expect(stats.noFlickerPairs).toBeGreaterThanOrEqual(16)
+  })
+
+  it('covers requested target colors among the achievable blends', () => {
+    // With saturated primaries as targets, the optimizer should be able to
+    // reproduce at least some of them exactly through a blend.
+    const { paletteA, paletteB } = optimizeModeRPalettes(
+      targets,
+      undefined,
+      baseConfig({ targetHardware: 'plus', useDualPalette: true })
+    )
+    const blends = new Set<string>()
+    for (const a of paletteA) {
+      for (const b of paletteB) {
+        blends.add(key(blendColors(a, b)))
+      }
+    }
+    // Black target [0,0,0] is always reproducible since black is forced in.
+    expect(blends.has('0,0,0')).toBe(true)
+  })
+
+  it('exercises the CPC Plus palette-B voting path with many varied targets', () => {
+    // A larger, varied set of explicit weights drives the candidate scoring,
+    // diversity and relaxation phases of palette B for CPC Plus.
+    const manyTargets: Vector<'RGB'>[] = []
+    for (let r = 0; r <= 255; r += 51) {
+      for (let g = 0; g <= 255; g += 85) {
+        manyTargets.push([r, g, 255 - r])
+      }
+    }
+    const weights = manyTargets.map((_, i) => i + 1)
+    const { paletteA, paletteB, stats } = optimizeModeRPalettes(
+      manyTargets,
+      weights,
+      baseConfig({ targetHardware: 'plus', useDualPalette: true })
+    )
+    expect(paletteA).toHaveLength(16)
+    expect(paletteB).toHaveLength(16)
+    expect(stats.uniquePerceivedColors).toBeGreaterThan(1)
+  })
+
+  it('exercises the CPC Classic palette-B voting path with varied targets', () => {
+    const manyTargets: Vector<'RGB'>[] = []
+    for (let r = 0; r <= 255; r += 85) {
+      for (let g = 0; g <= 255; g += 85) {
+        manyTargets.push([r, g, 128])
+      }
+    }
+    const weights = manyTargets.map((_, i) => i + 1)
+    const { paletteA, paletteB } = optimizeModeRPalettes(
+      manyTargets,
+      weights,
+      baseConfig({ targetHardware: 'classic', useDualPalette: true })
+    )
+    expect(paletteA).toHaveLength(16)
+    expect(paletteB).toHaveLength(16)
+  })
+
+  it('forces black into palettes that contain only bright colors', () => {
+    // Bright-only targets keep black out of the selection, exercising the
+    // "Added black for margin handling" replacement branch.
+    const brightTargets: Vector<'RGB'>[] = [
+      [255, 255, 255],
+      [255, 238, 255],
+      [238, 255, 255],
+      [255, 255, 238]
+    ]
+    const hasBlack = (palette: Vector<'RGB'>[]): boolean =>
+      palette.some((c) => c[0] <= 17 && c[1] <= 17 && c[2] <= 17)
+    const { paletteA, paletteB } = optimizeModeRPalettes(
+      brightTargets,
+      undefined,
+      baseConfig({ targetHardware: 'plus', useDualPalette: true })
+    )
+    // Black is guaranteed present afterward even though no target was dark.
+    expect(hasBlack(paletteA)).toBe(true)
+    expect(hasBlack(paletteB)).toBe(true)
+  })
+
+  it('default config (used as the literal default arg) yields valid palettes', () => {
+    const { paletteA, paletteB, pairs, stats } = optimizeModeRPalettes(
+      targets,
+      undefined
+    )
+    expect(paletteA).toHaveLength(16)
+    expect(paletteB).toHaveLength(16)
+    expect(pairs).toHaveLength(16)
+    expect(stats.uniquePerceivedColors).toBeGreaterThan(0)
+  })
+})

--- a/src/libs/pixsaur-raster/median-cut.spec.ts
+++ b/src/libs/pixsaur-raster/median-cut.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import type { Vector } from '../pixsaur-color/src/type'
+import { medianCut, type WeightedPixel } from './median-cut'
+
+const px = (color: Vector<'RGB'>, weight = 1): WeightedPixel => ({
+  color,
+  weight
+})
+
+describe('medianCut', () => {
+  it('returns an empty array for no pixels', () => {
+    expect(medianCut([], 4)).toEqual([])
+  })
+
+  it('passes colors through when there are at most numColors', () => {
+    const pixels = [px([255, 0, 0]), px([0, 255, 0])]
+    expect(medianCut(pixels, 4)).toEqual([
+      [255, 0, 0],
+      [0, 255, 0]
+    ])
+  })
+
+  it('passes colors through at exactly numColors', () => {
+    const pixels = [px([1, 1, 1]), px([2, 2, 2]), px([3, 3, 3])]
+    expect(medianCut(pixels, 3)).toHaveLength(3)
+  })
+
+  it('reduces to numColors representatives when there are more pixels', () => {
+    // Three well-separated clusters.
+    const pixels = [
+      px([250, 0, 0]),
+      px([240, 10, 5]),
+      px([0, 250, 0]),
+      px([5, 240, 10]),
+      px([0, 0, 250]),
+      px([10, 5, 240])
+    ]
+    const out = medianCut(pixels, 3)
+    expect(out).toHaveLength(3)
+    // Every representative comes from the input set.
+    const inputKeys = new Set(pixels.map((p) => p.color.join(',')))
+    for (const c of out) expect(inputKeys.has(c.join(','))).toBe(true)
+  })
+
+  it('picks the most frequent color as a box representative', () => {
+    // A heavy red plus a far blue: they end up in separate boxes, and the red
+    // box keeps the heaviest red.
+    const pixels = [
+      px([255, 0, 0], 100),
+      px([250, 5, 5], 1),
+      px([0, 0, 255], 1)
+    ]
+    const out = medianCut(pixels, 2)
+    expect(out).toHaveLength(2)
+    expect(out).toContainEqual([255, 0, 0])
+    expect(out).toContainEqual([0, 0, 255])
+  })
+
+  it('handles identical colors without producing empty boxes', () => {
+    const pixels = [
+      px([100, 100, 100]),
+      px([100, 100, 100]),
+      px([100, 100, 100]),
+      px([100, 100, 100])
+    ]
+    const out = medianCut(pixels, 2)
+    expect(out).toHaveLength(2)
+    for (const c of out) expect(c).toEqual([100, 100, 100])
+  })
+})


### PR DESCRIPTION
## Résumé

Campagne d'amélioration de la **couverture** (base 52,6 %), ciblant le code de lib **pur et déterministe** à 0 % (ROI maximal, zéro mock).

**7 fichiers, +149 tests**, chacun passant de ~0 % à **~95-100 %** lignes :

| Fichier | Tests | Couv. lignes |
|---|---|---|
| `pixsaur-adapter/cpu-convolution` | 16 | ~93% |
| `pixsaur-raster/median-cut` | 6 | ~93% |
| `pixsaur-mode-r/pair-optimizer` | 31 | ~99% |
| `pixsaur-egx/dithering` | 35 | 100% |
| `pixsaur-egx/palette-reorder` | 24 | ~99% |
| `pixsaur-egx/quantize-egx` | 20 | 100% |
| `pixsaur-egx/palette-optimizer` | 17 | ~99% |

Tests déterministes (pas de mock, pas d'aléa, pas de timing), portant sur les **contrats réels** (dimensions/alpha préservés, couleurs issues de la palette, bornes d'index par ligne, invariants d'algo). **Aucune modification du code source.** Suite complète : 2276 tests verts.

~1230 lignes auparavant non couvertes le sont désormais → la couverture globale devrait passer d'environ **53 % à ~64 %**.

## Reste à couvrir (mêmes principes)
`quantize-mode-r` (404 l., orchestration GPU/CPU), composants UI (editor-canvas, etc.), et l'orchestration export (`export-zip`).