### PR TITLE
test(sonar): use specific matchers (S5906) — 122 assertions

### DIFF
--- a/src/app/store/editor/editor-actions.spec.ts
+++ b/src/app/store/editor/editor-actions.spec.ts
@@ -100,7 +100,7 @@ describe('editor-actions', () => {
       }
 
       const history = store.get(editorHistoryAtom)
-      expect(history.length).toBe(MAX_HISTORY_SIZE)
+      expect(history).toHaveLength(MAX_HISTORY_SIZE)
     })
   })
 

--- a/src/app/store/preview/__tests__/manual-edits-export-integration.spec.ts
+++ b/src/app/store/preview/__tests__/manual-edits-export-integration.spec.ts
@@ -223,7 +223,7 @@ describe('Manual Edits Integration with Exports', () => {
       const result = applyManualEditsToBuffer(buffer, edits)
 
       // DSK workspace stores multiple images, each needs complete buffer data
-      expect(result.buffer.length).toBe(result.width * result.height)
+      expect(result.buffer).toHaveLength(result.width * result.height)
     })
   })
 })

--- a/src/app/store/preview/__tests__/preview.spec.ts
+++ b/src/app/store/preview/__tests__/preview.spec.ts
@@ -61,7 +61,7 @@ describe('applyManualEditsToBuffer', () => {
     const result = applyManualEditsToBuffer(buffer, edits)
 
     expect(result.buffer[0]).toBe(1)
-    expect(result.buffer.length).toBe(4)
+    expect(result.buffer).toHaveLength(4)
   })
 
   it('should preserve metadata', () => {

--- a/src/app/store/preview/mode-r/mode-r-preview.spec.ts
+++ b/src/app/store/preview/mode-r/mode-r-preview.spec.ts
@@ -73,7 +73,7 @@ describe('Mode R Resize Functions', () => {
       const src = createTestImageData(500, 300)
       const result = resizeForModeRAuto(src, 320, 200, true)
 
-      expect(result.data.length).toBe(320 * 200 * 4)
+      expect(result.data).toHaveLength(320 * 200 * 4)
     })
   })
 
@@ -114,7 +114,7 @@ describe('Mode R Resize Functions', () => {
       const src = createTestImageData(500, 300)
       const result = resizeForModeROrigin(src, 320, 200, true)
 
-      expect(result.data.length).toBe(320 * 200 * 4)
+      expect(result.data).toHaveLength(320 * 200 * 4)
     })
 
     it('should accept center parameter false', () => {

--- a/src/app/store/raster/raster.spec.ts
+++ b/src/app/store/raster/raster.spec.ts
@@ -358,7 +358,7 @@ describe('Raster Store', () => {
   describe('rasterOptimizationResultAtom', () => {
     it('should have null as default value', () => {
       const value = store.get(rasterOptimizationResultAtom)
-      expect(value).toBe(null)
+      expect(value).toBeNull()
     })
 
     it('should store optimization result', () => {
@@ -395,17 +395,17 @@ describe('Raster Store', () => {
       }
 
       store.set(rasterOptimizationResultAtom, result)
-      expect(store.get(rasterOptimizationResultAtom)).not.toBe(null)
+      expect(store.get(rasterOptimizationResultAtom)).not.toBeNull()
 
       store.set(clearRasterChangesAtom)
-      expect(store.get(rasterOptimizationResultAtom)).toBe(null)
+      expect(store.get(rasterOptimizationResultAtom)).toBeNull()
     })
   })
 
   describe('rasterIndexBufferAtom', () => {
     it('should return null when no optimization result exists', () => {
       const value = store.get(rasterIndexBufferAtom)
-      expect(value).toBe(null)
+      expect(value).toBeNull()
     })
 
     // Note: Testing rasterIndexBufferAtom with dithering requires mocking complex dependencies

--- a/src/components/color-palette/color-palette-view.spec.tsx
+++ b/src/components/color-palette/color-palette-view.spec.tsx
@@ -75,7 +75,7 @@ beforeEach(() => {
 describe('ColorPaletteView', () => {
   it('renders the correct number of slots', () => {
     renderWithStore(<ColorPaletteView {...props} />)
-    expect(screen.getAllByRole('button').length).toBe(3)
+    expect(screen.getAllByRole('button')).toHaveLength(3)
   })
 
   it('renders filled slots with color and lock state', () => {
@@ -118,8 +118,8 @@ describe('ColorPaletteView', () => {
             btn.title?.includes('Rouge') ||
             btn.title?.includes('Vert') ||
             btn.title?.includes('Bleu')
-        ).length
-    ).toBe(3)
+        )
+    ).toHaveLength(3)
   })
 
   it('opens popover when empty slot is clicked', () => {
@@ -138,8 +138,8 @@ describe('ColorPaletteView', () => {
             btn.title?.includes('Rouge') ||
             btn.title?.includes('Vert') ||
             btn.title?.includes('Bleu')
-        ).length
-    ).toBe(3)
+        )
+    ).toHaveLength(3)
   })
 
   it('calls onSetColor and closes popover when a color is selected', async () => {

--- a/src/components/dsk-workspace/dsk-workspace-manual-edits.spec.ts
+++ b/src/components/dsk-workspace/dsk-workspace-manual-edits.spec.ts
@@ -60,7 +60,7 @@ describe('DSK Workspace Manual Edits Integration', () => {
 
       // DSK workspace stores images that need complete metadata
       expect(finalBuffer.palette).toEqual(palette)
-      expect(finalBuffer.buffer.length).toBe(
+      expect(finalBuffer.buffer).toHaveLength(
         finalBuffer.width * finalBuffer.height
       )
     })

--- a/src/components/settings-panel/sections/raster-settings/raster-panel-view.spec.tsx
+++ b/src/components/settings-panel/sections/raster-settings/raster-panel-view.spec.tsx
@@ -199,7 +199,7 @@ describe('RasterPanelView', () => {
 
       // Check for change rows by looking for elements with lineRow class
       const changeRows = container.querySelectorAll('[class*="lineRow"]')
-      expect(changeRows.length).toBe(2)
+      expect(changeRows).toHaveLength(2)
     })
 
     it('should display line values', async () => {

--- a/src/components/source-selector/source-selector-view.spec.tsx
+++ b/src/components/source-selector/source-selector-view.spec.tsx
@@ -28,7 +28,7 @@ describe('SourceSelectorView', () => {
         <SourceSelectorView {...baseProps} />
       )
       const handles = container.querySelectorAll('[data-handle]')
-      expect(handles.length).toBe(4)
+      expect(handles).toHaveLength(4)
     })
 
     it('renders handles with correct names', () => {

--- a/src/components/source-selector/source-selector.spec.tsx
+++ b/src/components/source-selector/source-selector.spec.tsx
@@ -20,7 +20,7 @@ describe('SourceSelectorView', () => {
   it('renders four handles', () => {
     const { container } = renderWithI18n(<SourceSelectorView {...baseProps} />)
     const handles = container.querySelectorAll('[data-handle]')
-    expect(handles.length).toBe(4)
+    expect(handles).toHaveLength(4)
   })
 
   it('calls onMouseDown when mouse is pressed', () => {

--- a/src/export/exports/asm-templates.spec.ts
+++ b/src/export/exports/asm-templates.spec.ts
@@ -45,7 +45,7 @@ describe('generateDataSection', () => {
 
     const lines = result.split('\n')
     // 1 label line + 2 data lines (32 / 16 = 2)
-    expect(lines.length).toBe(3)
+    expect(lines).toHaveLength(3)
     expect(lines[1]).toContain('DB')
     expect(lines[2]).toContain('DB')
   })
@@ -56,7 +56,7 @@ describe('generateDataSection', () => {
 
     const lines = result.split('\n')
     // 1 label + 3 data lines (12 / 4 = 3)
-    expect(lines.length).toBe(4)
+    expect(lines).toHaveLength(4)
   })
 
   it('should handle empty data', () => {
@@ -99,7 +99,7 @@ describe('generatePaletteSection', () => {
     // Should only have 16 values
     const dbLine = result.split('\n')[1]
     const values = dbLine.split(',')
-    expect(values.length).toBe(16)
+    expect(values).toHaveLength(16)
   })
 
   it('should handle empty palette', () => {

--- a/src/export/exports/cpc-plus-format.spec.ts
+++ b/src/export/exports/cpc-plus-format.spec.ts
@@ -80,7 +80,7 @@ describe('cpc-plus-format', () => {
     it('should return little-endian bytes for black', () => {
       const bytes = rgbToCPCPlusBytes([0, 0, 0])
       expect(bytes).toBeInstanceOf(Uint8Array)
-      expect(bytes.length).toBe(2)
+      expect(bytes).toHaveLength(2)
       expect(bytes[0]).toBe(0x00) // Low byte: RRRR BBBB
       expect(bytes[1]).toBe(0x00) // High byte: 0000 GGGG
     })
@@ -109,12 +109,12 @@ describe('cpc-plus-format', () => {
   describe('paletteToCPCPlusData', () => {
     it('should convert empty palette', () => {
       const data = paletteToCPCPlusData([])
-      expect(data.length).toBe(0)
+      expect(data).toHaveLength(0)
     })
 
     it('should convert single color palette', () => {
       const data = paletteToCPCPlusData([[255, 255, 255]])
-      expect(data.length).toBe(2)
+      expect(data).toHaveLength(2)
       expect(data[0]).toBe(0xff)
       expect(data[1]).toBe(0x0f)
     })
@@ -126,7 +126,7 @@ describe('cpc-plus-format', () => {
         [255, 0, 0] // Red
       ]
       const data = paletteToCPCPlusData(palette)
-      expect(data.length).toBe(6) // 3 colors * 2 bytes
+      expect(data).toHaveLength(6) // 3 colors * 2 bytes
 
       // Black
       expect(data[0]).toBe(0x00)

--- a/src/export/exports/exporters/export-dsk-workspace-zip.spec.ts
+++ b/src/export/exports/exporters/export-dsk-workspace-zip.spec.ts
@@ -87,7 +87,7 @@ describe('exportDskWorkspaceZip', () => {
       const zip = await JSZip.loadAsync(result)
       expect(zip.files['IMG1.scr']).toBeDefined()
       const scrData = await zip.files['IMG1.scr'].async('uint8array')
-      expect(scrData.length).toBe(16384) // SCR file size
+      expect(scrData).toHaveLength(16384) // SCR file size
     }
   })
 
@@ -162,7 +162,7 @@ describe('exportDskWorkspaceZip', () => {
 
       // Verify chunk sizes — first chunk should be the max 16KiB and second
       // should contain the remaining bytes for the linear export.
-      expect(chunk1Data.length).toBe(16 * 1024) // 16KB max chunk
+      expect(chunk1Data).toHaveLength(16 * 1024) // 16KB max chunk
       expect(chunk2Data.length).toBeGreaterThan(0) // remaining chunk must be non-empty
     }
   })

--- a/src/export/exports/rgb-to-indexes/rgb-to-indexes.spec.ts
+++ b/src/export/exports/rgb-to-indexes/rgb-to-indexes.spec.ts
@@ -47,7 +47,7 @@ describe('rgbToIndexBufferExact', () => {
 
       const result = rgbToIndexBufferExact(rgbaBuffer, palette, false)
 
-      expect(result.length).toBe(1)
+      expect(result).toHaveLength(1)
       expect(result[0]).toBe(0)
     })
 
@@ -64,7 +64,7 @@ describe('rgbToIndexBufferExact', () => {
       const result = rgbToIndexBufferExact(rgbaBuffer, palette, false)
 
       expect(result).toBeInstanceOf(Uint8Array)
-      expect(result.length).toBe(5)
+      expect(result).toHaveLength(5)
     })
   })
 
@@ -130,7 +130,7 @@ describe('rgbToIndexBufferExact', () => {
 
       const result = rgbToIndexBufferExact(rgbaBuffer, palette, false)
 
-      expect(result.length).toBe(0)
+      expect(result).toHaveLength(0)
     })
 
     it('should ignore alpha channel for matching', () => {

--- a/src/export/exports/to-asm-data.spec.ts
+++ b/src/export/exports/to-asm-data.spec.ts
@@ -26,7 +26,7 @@ describe('toASMData', () => {
 
       const lines = result.split('\n')
       // 1 label + 2 data lines
-      expect(lines.length).toBe(3)
+      expect(lines).toHaveLength(3)
     })
 
     it('should handle empty data', () => {
@@ -61,8 +61,8 @@ describe('toASMData', () => {
 
       expect(Array.isArray(result)).toBe(true)
       expect(
-        (result as Array<{ filename: string; content: string }>).length
-      ).toBe(2)
+        result as Array<{ filename: string; content: string }>
+      ).toHaveLength(2)
     })
 
     it('should generate correct filenames for chunks', () => {
@@ -99,7 +99,7 @@ describe('toASMData', () => {
         content: string
       }>
 
-      expect(result.length).toBe(2)
+      expect(result).toHaveLength(2)
       expect(result[1].content).toContain('Size: 16 bytes')
     })
 

--- a/src/libs/pixsaur-adapter/adapters/__tests__/regl-quantizer-mode0-selection.spec.ts
+++ b/src/libs/pixsaur-adapter/adapters/__tests__/regl-quantizer-mode0-selection.spec.ts
@@ -306,7 +306,7 @@ describe('Mode 0 Selection Algorithm (production c244923)', () => {
       // Les deux rouges doivent être dans le même bucket (bucket 0: 0-45°)
       const bucket0 = buckets.get(0)
       expect(bucket0).toBeDefined()
-      expect(bucket0!.length).toBe(2)
+      expect(bucket0!).toHaveLength(2)
     })
 
     it('should put grayscale colors in gray bucket', () => {
@@ -328,7 +328,7 @@ describe('Mode 0 Selection Algorithm (production c244923)', () => {
 
       const buckets = createHueBuckets(colors)
 
-      expect(buckets.get('gray')!.length).toBe(3)
+      expect(buckets.get('gray')!).toHaveLength(3)
     })
   })
 

--- a/src/libs/pixsaur-adapter/adapters/regl-processor.spec.ts
+++ b/src/libs/pixsaur-adapter/adapters/regl-processor.spec.ts
@@ -154,7 +154,7 @@ describe('ReGLProcessor', () => {
       const capabilities = processor.getCapabilities()
 
       expect(capabilities.futureReGLCapable).toBe(false)
-      expect(capabilities.webglVersion).toBe(null)
+      expect(capabilities.webglVersion).toBeNull()
 
       // Restaurer
       Object.defineProperty(document, 'createElement', {
@@ -481,7 +481,7 @@ describe('ReGLProcessor', () => {
       const capabilities = processor.getCapabilities()
 
       expect(capabilities.futureReGLCapable).toBe(false)
-      expect(capabilities.webglVersion).toBe(null)
+      expect(capabilities.webglVersion).toBeNull()
       expect(capabilities.maxTextureSize).toBe(0)
 
       // Restaurer

--- a/src/libs/pixsaur-adapter/adapters/regl-quantizer-weighted.spec.ts
+++ b/src/libs/pixsaur-adapter/adapters/regl-quantizer-weighted.spec.ts
@@ -126,7 +126,7 @@ describe('ReGL Quantizer - Weighted Histogram Integration', () => {
       })
 
       expect(selectedBlueColors.length).toBeGreaterThan(0)
-      expect(result.length).toBe(config.targetColors)
+      expect(result).toHaveLength(config.targetColors)
     } finally {
       quantizer.dispose()
     }
@@ -160,12 +160,12 @@ describe('ReGL Quantizer - Weighted Histogram Integration', () => {
       // Vérifier que la quantification fonctionne
       expect(result).toBeDefined()
       expect(Array.isArray(result)).toBe(true)
-      expect(result.length).toBe(config.targetColors)
+      expect(result).toHaveLength(config.targetColors)
 
       // Chaque couleur devrait être un tableau RGB valide
       for (const color of result) {
         expect(Array.isArray(color)).toBe(true)
-        expect(color.length).toBe(3)
+        expect(color).toHaveLength(3)
         for (const component of color) {
           expect(typeof component).toBe('number')
           expect(component).toBeGreaterThanOrEqual(0)

--- a/src/libs/pixsaur-color/__tests__/quant/quantize-integration.spec.ts
+++ b/src/libs/pixsaur-color/__tests__/quant/quantize-integration.spec.ts
@@ -395,7 +395,7 @@ describe('quantize.ts - Integration Tests', () => {
       })
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(8) // 2 pixels * 4 channels
+      expect(result).toHaveLength(8) // 2 pixels * 4 channels
     })
 
     it('should handle no dithering mode', () => {

--- a/src/libs/pixsaur-color/src/map/__tests__/map-and-dither.extra.spec.ts
+++ b/src/libs/pixsaur-color/src/map/__tests__/map-and-dither.extra.spec.ts
@@ -101,7 +101,7 @@ describe('applyBlueNoiseDither (direct)', () => {
     })
 
     expect(result).toBeInstanceOf(Uint8ClampedArray)
-    expect(result.length).toBe(16)
+    expect(result).toHaveLength(16)
     expect(allPixelsInPalette(result, bwPalette)).toBe(true)
     expect(hasNoNaN(result)).toBe(true)
     // every alpha channel is opaque
@@ -140,7 +140,7 @@ describe('applyBlueNoiseDither (direct)', () => {
       correction: { enabled: false }
     })
 
-    expect(result.length).toBe(8)
+    expect(result).toHaveLength(8)
     expect(allPixelsInPalette(result, bwPalette)).toBe(true)
     expect(hasNoNaN(result)).toBe(true)
   })
@@ -157,7 +157,7 @@ describe('applyBlueNoiseDither (direct)', () => {
       distFn
     })
 
-    expect(result.length).toBe(4)
+    expect(result).toHaveLength(4)
     expect(allPixelsInPalette(result, bwPalette)).toBe(true)
   })
 })
@@ -178,7 +178,7 @@ describe('applyOstromoukhovDither (direct)', () => {
     })
 
     expect(result).toBeInstanceOf(Uint8ClampedArray)
-    expect(result.length).toBe(24)
+    expect(result).toHaveLength(24)
     expect(allPixelsInPalette(result, bwPalette)).toBe(true)
     expect(hasNoNaN(result)).toBe(true)
   })
@@ -196,7 +196,7 @@ describe('applyOstromoukhovDither (direct)', () => {
       correction: { enabled: false, errorClamp: 64 }
     })
 
-    expect(result.length).toBe(8)
+    expect(result).toHaveLength(8)
     expect(allPixelsInPalette(result, bwPalette)).toBe(true)
     expect(hasNoNaN(result)).toBe(true)
   })
@@ -214,7 +214,7 @@ describe('mapAndDither — blueNoise & ostromoukhov routing', () => {
       'RGB'
     )
 
-    expect(result.length).toBe(4 * 4 * 4)
+    expect(result).toHaveLength(4 * 4 * 4)
     expect(allPixelsInPalette(result, rgbPalette)).toBe(true)
     expect(hasNoNaN(result)).toBe(true)
   })
@@ -230,7 +230,7 @@ describe('mapAndDither — blueNoise & ostromoukhov routing', () => {
       'RGB'
     )
 
-    expect(result.length).toBe(4 * 4 * 4)
+    expect(result).toHaveLength(4 * 4 * 4)
     expect(allPixelsInPalette(result, rgbPalette)).toBe(true)
     expect(hasNoNaN(result)).toBe(true)
   })
@@ -278,7 +278,7 @@ describe('mapAndDitherWithDynamicPalette — blueNoise variant', () => {
       'RGB'
     )
 
-    expect(result.length).toBe(4 * 4 * 4)
+    expect(result).toHaveLength(4 * 4 * 4)
     expect(allPixelsInPalette(result, bwPalette)).toBe(true)
     expect(hasNoNaN(result)).toBe(true)
   })
@@ -306,7 +306,7 @@ describe('mapAndDitherWithDynamicPalette — blueNoise variant', () => {
       'RGB'
     )
 
-    expect(result.length).toBe(32)
+    expect(result).toHaveLength(32)
     // Line 0: only black or red allowed.
     for (let x = 0; x < 4; x++) {
       const idx = x * 4

--- a/src/libs/pixsaur-color/src/map/__tests__/map-and-dither.spec.ts
+++ b/src/libs/pixsaur-color/src/map/__tests__/map-and-dither.spec.ts
@@ -73,7 +73,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(16) // 4 pixels * 4 channels
+      expect(result).toHaveLength(16) // 4 pixels * 4 channels
     })
 
     it('should process image with Floyd-Steinberg dithering', () => {
@@ -87,7 +87,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(16)
+      expect(result).toHaveLength(16)
     })
 
     it('should process image with Bayer 2x2 dithering', () => {
@@ -101,7 +101,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(16)
+      expect(result).toHaveLength(16)
     })
 
     it('should process image with Bayer 4x4 dithering', () => {
@@ -115,7 +115,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(16)
+      expect(result).toHaveLength(16)
     })
 
     it('should process image with Bayer 8x8 dithering', () => {
@@ -129,7 +129,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(16)
+      expect(result).toHaveLength(16)
     })
 
     it('should process image with Yliluoma 1 dithering', () => {
@@ -143,7 +143,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(16)
+      expect(result).toHaveLength(16)
     })
 
     it('should process image with Yliluoma 2 dithering', () => {
@@ -157,7 +157,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(16)
+      expect(result).toHaveLength(16)
     })
 
     it('should handle single pixel image', () => {
@@ -172,7 +172,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(4)
+      expect(result).toHaveLength(4)
     })
 
     it('should handle empty image', () => {
@@ -187,7 +187,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(0)
+      expect(result).toHaveLength(0)
     })
 
     it('should handle unsupported dithering mode', () => {
@@ -201,7 +201,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(16)
+      expect(result).toHaveLength(16)
     })
 
     it('should work with different color spaces', () => {
@@ -215,7 +215,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(16)
+      expect(result).toHaveLength(16)
     })
   })
 
@@ -237,7 +237,7 @@ describe('Map and Dither', () => {
       const result = applyNoDither(bufCS, 2, 2, paletteCS, paletteOut, distFn)
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(16)
+      expect(result).toHaveLength(16)
     })
   })
 
@@ -266,7 +266,7 @@ describe('Map and Dither', () => {
       })
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(8)
+      expect(result).toHaveLength(8)
     })
   })
 
@@ -296,7 +296,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(36)
+      expect(result).toHaveLength(36)
     })
 
     it('should apply Bayer 4x4 dithering', () => {
@@ -322,7 +322,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(24)
+      expect(result).toHaveLength(24)
     })
   })
 
@@ -350,7 +350,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(8)
+      expect(result).toHaveLength(8)
     })
   })
 
@@ -378,7 +378,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(8)
+      expect(result).toHaveLength(8)
     })
   })
 
@@ -395,7 +395,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(16)
+      expect(result).toHaveLength(16)
     })
 
     it('should handle very small intensity values', () => {
@@ -409,7 +409,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(16)
+      expect(result).toHaveLength(16)
     })
 
     it('should handle maximum intensity values', () => {
@@ -423,7 +423,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(16)
+      expect(result).toHaveLength(16)
     })
 
     it('should handle large images', () => {
@@ -445,7 +445,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(100 * 100 * 4)
+      expect(result).toHaveLength(100 * 100 * 4)
     })
   })
 
@@ -461,7 +461,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(16)
+      expect(result).toHaveLength(16)
     })
 
     it('should process image with Halftone 4x4 dithering', () => {
@@ -475,7 +475,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(16)
+      expect(result).toHaveLength(16)
     })
 
     it('should apply halftone pattern correctly', () => {
@@ -500,7 +500,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(64)
+      expect(result).toHaveLength(64)
     })
   })
 
@@ -523,7 +523,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(16)
+      expect(result).toHaveLength(16)
     })
 
     it('should apply Bayer 2x2 with dynamic palette', () => {
@@ -544,7 +544,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(16)
+      expect(result).toHaveLength(16)
     })
 
     it('should apply Bayer 4x4 with dynamic palette', () => {
@@ -567,7 +567,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(16)
+      expect(result).toHaveLength(16)
     })
 
     it('should apply Bayer 8x8 with dynamic palette', () => {
@@ -595,7 +595,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(16)
+      expect(result).toHaveLength(16)
     })
 
     it('should apply halftone with dynamic palette', () => {
@@ -611,7 +611,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(16)
+      expect(result).toHaveLength(16)
     })
 
     it('should fallback to no dithering for unsupported modes', () => {
@@ -628,7 +628,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(16)
+      expect(result).toHaveLength(16)
     })
 
     it('should handle different palettes per line', () => {
@@ -664,7 +664,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(32)
+      expect(result).toHaveLength(32)
 
       // Line 0 pixels should be mapped to either black or red
       for (let x = 0; x < 4; x++) {
@@ -700,7 +700,7 @@ describe('Map and Dither', () => {
       )
 
       expect(result).toBeInstanceOf(Uint8ClampedArray)
-      expect(result.length).toBe(16)
+      expect(result).toHaveLength(16)
       // Should fallback to black
       expect(result[0]).toBe(0)
       expect(result[1]).toBe(0)

--- a/src/libs/pixsaur-color/src/quant/combination-scoring-helpers.spec.ts
+++ b/src/libs/pixsaur-color/src/quant/combination-scoring-helpers.spec.ts
@@ -225,7 +225,7 @@ describe('combination-scoring-helpers', () => {
 
       const result = selectWithHueDiversity(candidatesWithIndex, [], [], 3, 60)
 
-      expect(result.selectedIndices.length).toBe(3)
+      expect(result.selectedIndices).toHaveLength(3)
     })
 
     it('should skip similar hues', () => {
@@ -296,7 +296,7 @@ describe('combination-scoring-helpers', () => {
         [0, 255, 0] // Green ~120°
       ]
       const hues = getPreselectedHues(colors)
-      expect(hues.length).toBe(2)
+      expect(hues).toHaveLength(2)
     })
 
     it('should ignore gray colors', () => {
@@ -305,7 +305,7 @@ describe('combination-scoring-helpers', () => {
         [255, 0, 0]
       ]
       const hues = getPreselectedHues(colors)
-      expect(hues.length).toBe(1)
+      expect(hues).toHaveLength(1)
     })
   })
 
@@ -335,7 +335,7 @@ describe('combination-scoring-helpers', () => {
 
       const result = selectFallbackColors(candidates, [], 4)
 
-      expect(result.length).toBe(4)
+      expect(result).toHaveLength(4)
     })
 
     it('should add dark color first if not preselected', () => {

--- a/src/libs/pixsaur-color/src/quant/hue-diversity-helpers.spec.ts
+++ b/src/libs/pixsaur-color/src/quant/hue-diversity-helpers.spec.ts
@@ -204,7 +204,7 @@ describe('hue-diversity-helpers', () => {
 
       // First round: red1, green1, blue1
       // Second round: red2, green2
-      expect(result.length).toBe(5)
+      expect(result).toHaveLength(5)
       expect(result.map((c) => c.index)).toContain(0)
       expect(result.map((c) => c.index)).toContain(2)
       expect(result.map((c) => c.index)).toContain(4)
@@ -219,7 +219,7 @@ describe('hue-diversity-helpers', () => {
 
       const result = selectByRoundRobin(hueGroups, 2, [])
 
-      expect(result.length).toBe(2)
+      expect(result).toHaveLength(2)
     })
 
     it('should skip candidates too close to avoided colors', () => {
@@ -243,7 +243,7 @@ describe('hue-diversity-helpers', () => {
       const result = selectByRoundRobin(hueGroups, 5, [], [initial])
 
       expect(result[0].index).toBe(99)
-      expect(result.length).toBe(2)
+      expect(result).toHaveLength(2)
     })
   })
 
@@ -261,7 +261,7 @@ describe('hue-diversity-helpers', () => {
 
       const result = selectFromGroupsSequentially(categories, 10, [])
 
-      expect(result.length).toBe(3)
+      expect(result).toHaveLength(3)
       expect(result[0].index).toBe(0) // Red first
       expect(result[1].index).toBe(1) // Dark second
       expect(result[2].index).toBe(2) // Gray last
@@ -280,7 +280,7 @@ describe('hue-diversity-helpers', () => {
 
       const result = selectFromGroupsSequentially(categories, 2, [])
 
-      expect(result.length).toBe(2)
+      expect(result).toHaveLength(2)
     })
 
     it('should skip candidates too close to avoided colors', () => {
@@ -313,7 +313,7 @@ describe('hue-diversity-helpers', () => {
         [initial]
       )
 
-      expect(result.length).toBe(3)
+      expect(result).toHaveLength(3)
       expect(result.map((c) => c.index)).toContain(2) // Initial preserved
       expect(result.map((c) => c.index)).toContain(0) // Frequent added
       expect(result.map((c) => c.index)).toContain(1) // Less frequent added
@@ -325,7 +325,7 @@ describe('hue-diversity-helpers', () => {
 
       const result = fillWithMostFrequent([c1, c2], 1, [], [])
 
-      expect(result.length).toBe(1)
+      expect(result).toHaveLength(1)
     })
 
     it('should skip candidates too close to avoided colors', () => {
@@ -346,7 +346,7 @@ describe('hue-diversity-helpers', () => {
 
       const indices = result.map((c) => c.index)
       const uniqueIndices = [...new Set(indices)]
-      expect(indices.length).toBe(uniqueIndices.length)
+      expect(indices).toHaveLength(uniqueIndices.length)
     })
   })
 })

--- a/src/libs/pixsaur-color/src/quant/mode0-hue-diversity.spec.ts
+++ b/src/libs/pixsaur-color/src/quant/mode0-hue-diversity.spec.ts
@@ -309,7 +309,7 @@ describe('color-selection-helpers', () => {
 
       const reps = selectBucketRepresentatives(buckets, 10)
 
-      expect(reps.length).toBe(2)
+      expect(reps).toHaveLength(2)
       expect(reps[0].index).toBe(0) // Most frequent from first bucket
       expect(reps[1].index).toBe(2) // Most frequent from second bucket
     })
@@ -356,7 +356,7 @@ describe('color-selection-helpers', () => {
 
       const reps = selectBucketRepresentatives(buckets, 2)
 
-      expect(reps.length).toBe(2)
+      expect(reps).toHaveLength(2)
     })
 
     it('should skip empty buckets', () => {
@@ -382,7 +382,7 @@ describe('color-selection-helpers', () => {
 
       const reps = selectBucketRepresentatives(buckets, 10)
 
-      expect(reps.length).toBe(1)
+      expect(reps).toHaveLength(1)
       expect(reps[0].index).toBe(1)
     })
   })
@@ -436,7 +436,7 @@ describe('color-selection-helpers', () => {
       const reps = selectBucketRepresentativesWithLightness(buckets, 10)
 
       // All three buckets should be represented (no mega-family restrictions)
-      expect(reps.length).toBe(3)
+      expect(reps).toHaveLength(3)
       expect(reps.map((r) => r.index)).toContain(0)
       expect(reps.map((r) => r.index)).toContain(1)
       expect(reps.map((r) => r.index)).toContain(2)
@@ -472,7 +472,7 @@ describe('color-selection-helpers', () => {
 
       const reps = selectBucketRepresentativesWithLightness(buckets, 10)
 
-      expect(reps.length).toBe(2)
+      expect(reps).toHaveLength(2)
     })
   })
 
@@ -567,7 +567,7 @@ describe('color-selection-helpers', () => {
         simpleDistance
       )
 
-      expect(result.length).toBe(0)
+      expect(result).toHaveLength(0)
     })
   })
 

--- a/src/libs/pixsaur-egx/dithering.spec.ts
+++ b/src/libs/pixsaur-egx/dithering.spec.ts
@@ -140,7 +140,7 @@ describe('applyEGXDitheringByMode', () => {
       1
     )
     expect(out).toBeInstanceOf(Uint8ClampedArray)
-    expect(out.length).toBe(width * height * 4)
+    expect(out).toHaveLength(width * height * 4)
     // Alpha is always forced to 255 by every EGX ditherer.
     for (let i = 3; i < out.length; i += 4) {
       expect(out[i]).toBe(255)
@@ -363,7 +363,7 @@ describe('applyEGXDitheringByMode', () => {
     ])
     for (const mode of ALL_MODES) {
       const out = applyEGXDitheringByMode(img, EGX2_PALETTE, config, mode, 1)
-      expect(out.length).toBe(width * height * 4)
+      expect(out).toHaveLength(width * height * 4)
       expectAllColorsInSubPalette(out, width, height, EGX2_PALETTE, config)
     }
   })
@@ -407,7 +407,7 @@ describe('applyEGXDitheringByMode', () => {
       'floydSteinberg',
       1
     )
-    expect(on.length).toBe(off.length)
+    expect(on).toHaveLength(off.length)
     expectAllColorsInSubPalette(on, 6, 4, EGX1_PALETTE, makeConfig())
     expectAllColorsInSubPalette(off, 6, 4, EGX1_PALETTE, makeConfig())
   })
@@ -428,7 +428,7 @@ describe('applyEGXDitheringByMode', () => {
       'bayer4x4',
       1
     )
-    expect(on.length).toBe(off.length)
+    expect(on).toHaveLength(off.length)
     expectAllColorsInSubPalette(on, 6, 4, EGX1_PALETTE, makeConfig())
     expectAllColorsInSubPalette(off, 6, 4, EGX1_PALETTE, makeConfig())
   })

--- a/src/libs/pixsaur-egx/palette-reorder.spec.ts
+++ b/src/libs/pixsaur-egx/palette-reorder.spec.ts
@@ -91,7 +91,7 @@ describe('combinations', () => {
       [7, 4]
     ] as const) {
       const arr = Array.from({ length: n }, (_, i) => i)
-      expect(toArray(combinations(arr, k)).length).toBe(cnk(n, k))
+      expect(toArray(combinations(arr, k))).toHaveLength(cnk(n, k))
     }
   })
 
@@ -239,7 +239,7 @@ describe('optimizePaletteForEGX', () => {
       [4, 0]
     ])
     const result = optimizePaletteForEGX(palette, usage, 2, false)
-    expect(result.length).toBe(palette.length)
+    expect(result).toHaveLength(palette.length)
   })
 
   it('every output color comes from the input palette (classic)', () => {
@@ -338,7 +338,7 @@ describe('optimizePaletteForEGX', () => {
     ]
     const usage = new Map<number, number>([[0, 5]])
     const result = optimizePaletteForEGX(smallPalette, usage, 2, false)
-    expect(result.length).toBe(smallPalette.length)
+    expect(result).toHaveLength(smallPalette.length)
     // Last slot is padded black since only one index was known
     expect(result[result.length - 1]).toEqual([0, 0, 0])
   })
@@ -399,7 +399,7 @@ describe('optimizePaletteForEGX', () => {
       [3, 10]
     ])
     const result = optimizePaletteForEGX(clusteredPalette, usage, 2, true)
-    expect(result.length).toBe(clusteredPalette.length)
+    expect(result).toHaveLength(clusteredPalette.length)
     // Fallback keeps the two most-used colors and every input color survives
     const resultSet = new Set(result.map((c) => (c as number[]).join(',')))
     for (const c of clusteredPalette) {

--- a/src/libs/pixsaur-egx/quantize-egx.spec.ts
+++ b/src/libs/pixsaur-egx/quantize-egx.spec.ts
@@ -73,7 +73,7 @@ describe('quantizeEGX', () => {
     const dims = getEGXOutputDimensions('egx1')
     expect(result.width).toBe(dims.width)
     expect(result.height).toBe(dims.height)
-    expect(result.indexBuffer.length).toBe(dims.width * dims.height)
+    expect(result.indexBuffer).toHaveLength(dims.width * dims.height)
   })
 
   it('produces the EGX2 output dimensions regardless of input size', () => {
@@ -82,7 +82,7 @@ describe('quantizeEGX', () => {
     const dims = getEGXOutputDimensions('egx2')
     expect(result.width).toBe(dims.width)
     expect(result.height).toBe(dims.height)
-    expect(result.indexBuffer.length).toBe(dims.width * dims.height)
+    expect(result.indexBuffer).toHaveLength(dims.width * dims.height)
   })
 
   it('emits one line encoding per output line', () => {
@@ -189,7 +189,7 @@ describe('quantizeEGX', () => {
     const result = quantizeEGX(input, dims.width, dims.height, egx1Config)
     expect(result.width).toBe(dims.width)
     expect(result.height).toBe(dims.height)
-    expect(result.indexBuffer.length).toBe(dims.width * dims.height)
+    expect(result.indexBuffer).toHaveLength(dims.width * dims.height)
   })
 })
 
@@ -198,7 +198,7 @@ describe('generateEGXPreview', () => {
     const input = makeBuffer(4, 2, uniform(120, 60, 30))
     const result = quantizeEGX(input, 4, 2, egx1Config)
     const preview = generateEGXPreview(result)
-    expect(preview.length).toBe(result.width * result.height * 4)
+    expect(preview).toHaveLength(result.width * result.height * 4)
     expect(preview).toBeInstanceOf(Uint8ClampedArray)
   })
 
@@ -286,7 +286,7 @@ describe('generateEGXPreviewMode0', () => {
     const result = quantizeEGX(input, 4, 2, egx1Config)
     const preview = generateEGXPreviewMode0(result)
     const outWidth = Math.floor(result.width / 2)
-    expect(preview.length).toBe(outWidth * result.height * 4)
+    expect(preview).toHaveLength(outWidth * result.height * 4)
   })
 
   it('takes every other pixel on Mode 0 lines', () => {

--- a/src/libs/pixsaur-raster/optimize-line-palettes.spec.ts
+++ b/src/libs/pixsaur-raster/optimize-line-palettes.spec.ts
@@ -172,7 +172,7 @@ describe('extractGlobalPaletteFromImage', () => {
     const palette = extractGlobalPaletteFromImage(image, 16)
 
     // Should only have 1 color since image is solid
-    expect(palette.length).toBe(1)
+    expect(palette).toHaveLength(1)
     expect(palette[0]).toEqual([0, 0, 0])
   })
 
@@ -186,7 +186,7 @@ describe('extractGlobalPaletteFromImage', () => {
     // 100/17 ≈ 5.9 → 6*17 = 102
     // 150/17 ≈ 8.8 → 9*17 = 153
     // 200/17 ≈ 11.8 → 12*17 = 204
-    expect(palette.length).toBe(1)
+    expect(palette).toHaveLength(1)
     expect(palette[0]).toEqual([102, 153, 204])
   })
 
@@ -211,7 +211,7 @@ describe('extractGlobalPaletteFromImage', () => {
     const image = createTestImage(4, 4, pixels)
     const palette = extractGlobalPaletteFromImage(image, 4)
 
-    expect(palette.length).toBe(4)
+    expect(palette).toHaveLength(4)
   })
 })
 
@@ -301,7 +301,7 @@ describe('extractGlobalPaletteFromImage with tuning params', () => {
     // Request only 4 colors - should trigger farthest point selection
     const palette = extractGlobalPaletteFromImage(image, 4)
 
-    expect(palette.length).toBe(4)
+    expect(palette).toHaveLength(4)
   })
 
   it('should respect frequencyExponent parameter', () => {
@@ -331,8 +331,8 @@ describe('extractGlobalPaletteFromImage with tuning params', () => {
     const paletteLowFreq = extractGlobalPaletteFromImage(image, 2)
 
     // Both should have 2 colors
-    expect(paletteHighFreq.length).toBe(2)
-    expect(paletteLowFreq.length).toBe(2)
+    expect(paletteHighFreq).toHaveLength(2)
+    expect(paletteLowFreq).toHaveLength(2)
 
     // The first color (most frequent) should be red in high freq mode
     // Note: colors are quantized to CPC Plus, so [255, 0, 0] stays [255, 0, 0]
@@ -609,7 +609,7 @@ describe('optimizeLinePalettesWithIndexBuffer', () => {
     expect(result).toHaveProperty('changes')
     expect(result).toHaveProperty('indexBuffer')
     expect(result).toHaveProperty('quantizedGlobalPalette')
-    expect(result.indexBuffer.length).toBe(width * height)
+    expect(result.indexBuffer).toHaveLength(width * height)
   })
 
   it('should generate correct index buffer for single-color image', () => {

--- a/src/libs/rasm-wasm/__tests__/rasm-wasm-concurrency.spec.ts
+++ b/src/libs/rasm-wasm/__tests__/rasm-wasm-concurrency.spec.ts
@@ -57,7 +57,7 @@ describe('rasm-wasm concurrency', () => {
       await Promise.all([p1, p2])
 
       // We should have two write events
-      expect(writeTimestamps.length).toBe(2)
+      expect(writeTimestamps).toHaveLength(2)
 
       // The second write should happen at least ~TEST_DELAY after the first
       const diff = writeTimestamps[1] - writeTimestamps[0]

--- a/src/libs/rasm-wasm/__tests__/rasm-wasm.spec.ts
+++ b/src/libs/rasm-wasm/__tests__/rasm-wasm.spec.ts
@@ -126,7 +126,7 @@ describe('rasm-wasm helpers', () => {
     // Both callMain invocations should have happened
     expect(mockModule.callMain).toHaveBeenCalledTimes(2)
     // The recorded timestamps should be ordered - second should be later
-    expect(calls.length).toBe(2)
+    expect(calls).toHaveLength(2)
     expect(calls[0]).toBeLessThanOrEqual(calls[1])
 
     // Dispose should wait for any queued operations to finish
@@ -217,7 +217,7 @@ describe('rasm-wasm helpers', () => {
     it('should handle Uint8Array input', () => {
       const input = new Uint8Array([1, 2, 3])
       // toUint8Array should return the same array
-      expect(input instanceof Uint8Array).toBe(true)
+      expect(input).toBeInstanceOf(Uint8Array)
     })
 
     it('should handle string input', () => {

--- a/src/preview/image-processing/horizontal-smoothing.spec.ts
+++ b/src/preview/image-processing/horizontal-smoothing.spec.ts
@@ -121,7 +121,7 @@ describe('applyHorizontalSmoothing', () => {
     // Should not throw and produce valid output
     expect(result.width).toBe(3)
     expect(result.height).toBe(1)
-    expect(result.data.length).toBe(12)
+    expect(result.data).toHaveLength(12)
   })
 
   it('preserves alpha channel correctly', () => {


### PR DESCRIPTION
Closes 122 SonarCloud `typescript:S5906` issues ("Prefer a more specific assertion instead of this generic one").

## What
Replace generic assertions with specific matchers across 31 spec files:
- `expect(x.length).toBe(n)` → `expect(x).toHaveLength(n)` (112, via balanced-paren codemod on the exact flagged lines)
- `expect(x).toBe(null)` → `expect(x).toBeNull()`
- `expect(x instanceof T).toBe(true)` → `expect(x).toBeInstanceOf(T)`

## Safety
- **Test-only, zero behavior change.**
- 583 tests green on the touched files.
- typecheck, biome, and all custom guards pass (pre-commit).

Part of the SonarCloud cleanup (bucket 1/… — the 73% mechanical win).