### PR TITLE
chore(sonar): safe quick wins — CSS overflow-wrap + unique test titles

### DIFF
--- a/src/components/color-palette/color-palette-view.spec.tsx
+++ b/src/components/color-palette/color-palette-view.spec.tsx
@@ -122,7 +122,7 @@ describe('ColorPaletteView', () => {
     ).toHaveLength(3)
   })
 
-  it('opens popover when empty slot is clicked', () => {
+  it('shows popover synchronously when empty slot is clicked', () => {
     renderWithStore(<ColorPaletteView {...props} />)
     fireEvent.click(
       screen.getByRole('button', { name: /Ajouter une couleur/i })

--- a/src/components/dsk-workspace/dsk-workspace.module.css
+++ b/src/components/dsk-workspace/dsk-workspace.module.css
@@ -92,7 +92,7 @@
   flex-wrap: wrap;
   gap: 0.375rem;
   min-width: 0;
-  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 .hardwareBadgeClassic,

--- a/src/components/error-boundary/error-boundary.module.css
+++ b/src/components/error-boundary/error-boundary.module.css
@@ -51,7 +51,7 @@
   font-size: var(--font-size-xs);
   text-align: left;
   white-space: pre-wrap;
-  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 .actions {

--- a/src/components/ui/color-picker-popup/color-picker-popup.spec.tsx
+++ b/src/components/ui/color-picker-popup/color-picker-popup.spec.tsx
@@ -71,14 +71,6 @@ describe('ColorPickerPopup', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
-  it('should call onClose when cancel button is clicked', async () => {
-    const onClose = vi.fn()
-    renderWithI18n(<ColorPickerPopup {...defaultProps} onClose={onClose} />)
-
-    await userEvent.click(screen.getByText('Annuler'))
-    expect(onClose).toHaveBeenCalledTimes(1)
-  })
-
   it('should call onColorConfirm and onClose when validate button is clicked', async () => {
     const onColorConfirm = vi.fn()
     const onClose = vi.fn()


### PR DESCRIPTION
Closes 4 SonarCloud issues, all with zero runtime-behavior change.

- `word-break: break-word` → `overflow-wrap: break-word` ×2 (`css:S1874`, deprecated keyword)
- rename the synchronous popover test to a unique title (`typescript:S8754`)
- remove a byte-identical duplicate `onClose` test (`typescript:S8754`)

## Deferred (not in this PR)
- **S107** `selectFrequentColorsWithDiversity` (8 params) — lives in `mode0-hue-diversity.ts`, protected by CLAUDE.md and Stryker; belongs with the S3776 refactor batch.
- **S7785** top-level await for `initI18n` — changes app-bootstrap timing (blocking module eval vs fire-and-forget); needs a deliberate decision.

Note: `color-palette-view.spec.tsx` is also touched by the S5906 PR — merge that one first to avoid a trivial conflict.