### PR TITLE
refactor: reduce cognitive complexity — S3776 batch 2 (egx + raster)

### DIFF
--- a/src/libs/pixsaur-egx/dithering.ts
+++ b/src/libs/pixsaur-egx/dithering.ts
@@ -401,6 +401,39 @@ function applyEGXNoDithering(
   return output
 }
 
+type EGXPaletteBounds = ReturnType<typeof computeEGXPaletteBounds>
+
+/** True when a channel value sits at (or just inside) the palette gamut edge. */
+function isAtGamutBoundary(value: number, min: number, max: number): boolean {
+  return value <= min + 1 || value >= max - 1
+}
+
+/**
+ * Applies the ordered-dithering perturbation to a pixel, leaving it untouched
+ * when it sits at the palette gamut boundary on all three channels.
+ */
+function perturbForOrderedDithering(
+  sr: number,
+  sg: number,
+  sb: number,
+  threshold: number,
+  bounds: EGXPaletteBounds | null
+): [number, number, number] {
+  const skip =
+    bounds !== null &&
+    isAtGamutBoundary(sr, bounds.min[0], bounds.max[0]) &&
+    isAtGamutBoundary(sg, bounds.min[1], bounds.max[1]) &&
+    isAtGamutBoundary(sb, bounds.min[2], bounds.max[2])
+  if (skip) {
+    return [sr, sg, sb]
+  }
+  return [
+    Math.max(0, Math.min(255, sr + threshold)),
+    Math.max(0, Math.min(255, sg + threshold)),
+    Math.max(0, Math.min(255, sb + threshold))
+  ]
+}
+
 /**
  * Ordered dithering (Bayer) adapted for EGX mode
  */
@@ -465,23 +498,13 @@ function applyEGXOrderedDithering(
       const threshold = (bayerVal / divisor - 0.5) * amplitude
 
       // Skip perturbation when pixel is at palette gamut boundary
-      const sr = data[idx],
-        sg = data[idx + 1],
-        sb = data[idx + 2]
-      const skipPerturbation =
-        orderedBounds !== null &&
-        (sr <= orderedBounds.min[0] + 1 || sr >= orderedBounds.max[0] - 1) &&
-        (sg <= orderedBounds.min[1] + 1 || sg >= orderedBounds.max[1] - 1) &&
-        (sb <= orderedBounds.min[2] + 1 || sb >= orderedBounds.max[2] - 1)
-      const r = skipPerturbation
-        ? sr
-        : Math.max(0, Math.min(255, sr + threshold))
-      const g = skipPerturbation
-        ? sg
-        : Math.max(0, Math.min(255, sg + threshold))
-      const b = skipPerturbation
-        ? sb
-        : Math.max(0, Math.min(255, sb + threshold))
+      const [r, g, b] = perturbForOrderedDithering(
+        data[idx],
+        data[idx + 1],
+        data[idx + 2],
+        threshold,
+        orderedBounds
+      )
 
       const { color } = findClosestInSubset([r, g, b], palette, maxColorIndex)
 

--- a/src/libs/pixsaur-raster/ink-assignment.spec.ts
+++ b/src/libs/pixsaur-raster/ink-assignment.spec.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import type { Vector } from '../pixsaur-color/src/type'
+import { assignColorsToInks } from './ink-assignment'
+
+describe('assignColorsToInks', () => {
+  it('returns a copy of the previous palette when the line has no colors', () => {
+    const previous: Vector<'RGB'>[] = [
+      [10, 10, 10],
+      [20, 20, 20]
+    ]
+
+    const result = assignColorsToInks([], previous)
+
+    expect(result).toEqual(previous)
+  })
+
+  it('does not alias the previous palette when the line is empty', () => {
+    const previous: Vector<'RGB'>[] = [[10, 10, 10]]
+
+    const result = assignColorsToInks([], previous)
+
+    expect(result[0]).not.toBe(previous[0])
+  })
+
+  it('keeps an exact match in its previous ink position', () => {
+    const previous: Vector<'RGB'>[] = [
+      [10, 10, 10],
+      [20, 20, 20]
+    ]
+
+    const result = assignColorsToInks([[20, 20, 20]], previous)
+
+    expect(result[1]).toEqual([20, 20, 20])
+  })
+
+  it('assigns a new color to the first unused ink slot', () => {
+    const previous: Vector<'RGB'>[] = [
+      [10, 10, 10],
+      [20, 20, 20]
+    ]
+
+    const result = assignColorsToInks([[99, 99, 99]], previous)
+
+    expect(result[0]).toEqual([99, 99, 99])
+  })
+
+  it('fills free slots around exact matches', () => {
+    const previous: Vector<'RGB'>[] = [
+      [10, 10, 10],
+      [20, 20, 20]
+    ]
+
+    const result = assignColorsToInks(
+      [
+        [20, 20, 20],
+        [99, 99, 99]
+      ],
+      previous
+    )
+
+    expect(result).toEqual([
+      [99, 99, 99],
+      [20, 20, 20]
+    ])
+  })
+
+  it('drops line colors that exceed the available ink slots', () => {
+    const previous: Vector<'RGB'>[] = [[0, 0, 0]]
+
+    const result = assignColorsToInks(
+      [
+        [1, 1, 1],
+        [2, 2, 2]
+      ],
+      previous
+    )
+
+    expect(result).toEqual([[1, 1, 1]])
+  })
+
+  it('does not assign the same line color twice', () => {
+    const previous: Vector<'RGB'>[] = [
+      [0, 0, 0],
+      [9, 9, 9]
+    ]
+
+    const result = assignColorsToInks(
+      [
+        [5, 5, 5],
+        [5, 5, 5]
+      ],
+      previous
+    )
+
+    expect(result).toEqual([
+      [5, 5, 5],
+      [9, 9, 9]
+    ])
+  })
+})

--- a/src/libs/pixsaur-raster/ink-assignment.ts
+++ b/src/libs/pixsaur-raster/ink-assignment.ts
@@ -16,11 +16,60 @@ import { colorKey } from './palette-selection'
  * @param previousPalette - The palette from the previous line
  * @returns New palette with lineColors assigned to ink indices
  */
+/** Mutable bookkeeping shared across the two assignment passes. */
+interface InkAssignmentState {
+  newPalette: Vector<'RGB'>[]
+  assignedColors: Set<string>
+  usedInks: Set<number>
+}
+
+/**
+ * First pass: keep any line color that exactly matches the previous palette in
+ * its original ink position, so unchanged colors never move.
+ */
+function assignExactMatches(
+  previousPalette: Vector<'RGB'>[],
+  lineColors: Vector<'RGB'>[],
+  state: InkAssignmentState
+): void {
+  previousPalette.forEach((prevColor, inkIndex) => {
+    const prevKey = colorKey(prevColor)
+    const match = state.assignedColors.has(prevKey)
+      ? undefined
+      : lineColors.find((lineColor) => colorKey(lineColor) === prevKey)
+    if (match) {
+      state.newPalette[inkIndex] = match
+      state.assignedColors.add(prevKey)
+      state.usedInks.add(inkIndex)
+    }
+  })
+}
+
+/** Second pass: place each not-yet-assigned line color into the first free ink. */
+function assignRemainingToFreeInks(
+  lineColors: Vector<'RGB'>[],
+  numInks: number,
+  state: InkAssignmentState
+): void {
+  for (const lineColor of lineColors) {
+    const lineKey = colorKey(lineColor)
+    if (state.assignedColors.has(lineKey)) continue
+
+    for (let inkIndex = 0; inkIndex < numInks; inkIndex++) {
+      if (!state.usedInks.has(inkIndex)) {
+        state.newPalette[inkIndex] = lineColor
+        state.assignedColors.add(lineKey)
+        state.usedInks.add(inkIndex)
+        break
+      }
+    }
+  }
+}
+
 export function assignColorsToInks(
   lineColors: Vector<'RGB'>[],
   previousPalette: Vector<'RGB'>[]
 ): Vector<'RGB'>[] {
-  const numInks = previousPalette.length
   const newPalette = previousPalette.map((c) => [...c]) as Vector<'RGB'>[]
 
   // If no colors on this line, keep previous palette
@@ -28,42 +77,14 @@ export function assignColorsToInks(
     return newPalette
   }
 
-  // Track which line colors have been assigned and which inks are used
-  const assignedColors = new Set<string>()
-  const usedInks = new Set<number>()
-
-  // First pass: exact matches - keep colors in the same ink position
-  for (let inkIndex = 0; inkIndex < numInks; inkIndex++) {
-    const prevColor = previousPalette[inkIndex]
-    const prevKey = colorKey(prevColor)
-
-    for (const lineColor of lineColors) {
-      const lineKey = colorKey(lineColor)
-      if (lineKey === prevKey && !assignedColors.has(lineKey)) {
-        // Exact match - keep in same position
-        newPalette[inkIndex] = lineColor
-        assignedColors.add(lineKey)
-        usedInks.add(inkIndex)
-        break
-      }
-    }
+  const state: InkAssignmentState = {
+    newPalette,
+    assignedColors: new Set<string>(),
+    usedInks: new Set<number>()
   }
 
-  // Second pass: assign remaining line colors to unused ink slots
-  for (const lineColor of lineColors) {
-    const lineKey = colorKey(lineColor)
-    if (assignedColors.has(lineKey)) continue
-
-    // Find first unused ink slot
-    for (let inkIndex = 0; inkIndex < numInks; inkIndex++) {
-      if (!usedInks.has(inkIndex)) {
-        newPalette[inkIndex] = lineColor
-        assignedColors.add(lineKey)
-        usedInks.add(inkIndex)
-        break
-      }
-    }
-  }
+  assignExactMatches(previousPalette, lineColors, state)
+  assignRemainingToFreeInks(lineColors, previousPalette.length, state)
 
   return newPalette
 }

--- a/src/libs/pixsaur-raster/line-palette-optimizer.ts
+++ b/src/libs/pixsaur-raster/line-palette-optimizer.ts
@@ -369,6 +369,51 @@ export function optimizeLinePalettesWithIndexBuffer(
 // Helper Functions
 // ============================================================================
 
+/**
+ * Resolves the fixed (non-raster) colors for a Mode 0 CPC Plus base palette,
+ * either from the caller-provided palette or by extracting them from the image.
+ */
+function resolveMode0PlusFixedColors(
+  preprocessedImage: ImageData,
+  globalPalette: Vector<'RGB'>[],
+  numRasterSlots: number,
+  numFixedColors: number,
+  cpcClassicPalette: Vector<'RGB'>[] | undefined,
+  useProvidedPalette: boolean,
+  quantizeColor: (color: Vector<'RGB'>) => Vector<'RGB'>
+): Vector<'RGB'>[] {
+  const extractFromImage = () =>
+    extractGlobalColorsForMode0Plus(
+      preprocessedImage,
+      cpcClassicPalette,
+      numFixedColors
+    )
+
+  if (!(useProvidedPalette && globalPalette.length > 0)) {
+    return extractFromImage()
+  }
+
+  if (globalPalette.length === numFixedColors) {
+    return globalPalette.map((c) => quantizeColor(c))
+  }
+
+  if (globalPalette.length >= MODE_0_TOTAL_COLORS) {
+    return globalPalette
+      .slice(numRasterSlots, MODE_0_TOTAL_COLORS)
+      .map((c) => quantizeColor(c))
+  }
+
+  // Too few provided colors: quantize what we have, then pad from the image.
+  const globalColors = globalPalette.map((c) => quantizeColor(c))
+  if (globalColors.length < numFixedColors) {
+    const extracted = extractFromImage()
+    while (globalColors.length < numFixedColors) {
+      globalColors.push(extracted[globalColors.length] || [0, 0, 0])
+    }
+  }
+  return globalColors
+}
+
 function setupMode0PlusPalette(
   preprocessedImage: ImageData,
   globalPalette: Vector<'RGB'>[],
@@ -384,34 +429,15 @@ function setupMode0PlusPalette(
   const numRasterSlots = Math.min(maxChangesPerLine, MODE_0_RASTER_SLOTS)
   const numFixedColors = MODE_0_TOTAL_COLORS - numRasterSlots
 
-  let globalColors: Vector<'RGB'>[]
-  if (useProvidedPalette && globalPalette.length > 0) {
-    if (globalPalette.length === numFixedColors) {
-      globalColors = globalPalette.map((c) => quantizeColor(c))
-    } else if (globalPalette.length >= MODE_0_TOTAL_COLORS) {
-      globalColors = globalPalette
-        .slice(numRasterSlots, MODE_0_TOTAL_COLORS)
-        .map((c) => quantizeColor(c))
-    } else {
-      globalColors = globalPalette.map((c) => quantizeColor(c))
-      if (globalColors.length < numFixedColors) {
-        const extracted = extractGlobalColorsForMode0Plus(
-          preprocessedImage,
-          cpcClassicPalette,
-          numFixedColors
-        )
-        while (globalColors.length < numFixedColors) {
-          globalColors.push(extracted[globalColors.length] || [0, 0, 0])
-        }
-      }
-    }
-  } else {
-    globalColors = extractGlobalColorsForMode0Plus(
-      preprocessedImage,
-      cpcClassicPalette,
-      numFixedColors
-    )
-  }
+  const globalColors = resolveMode0PlusFixedColors(
+    preprocessedImage,
+    globalPalette,
+    numRasterSlots,
+    numFixedColors,
+    cpcClassicPalette,
+    useProvidedPalette,
+    quantizeColor
+  )
 
   const basePalette = new Array(MODE_0_TOTAL_COLORS) as Vector<'RGB'>[]
   for (let i = 0; i < numRasterSlots; i++) {

--- a/src/libs/pixsaur-raster/optimize-line-palettes.spec.ts
+++ b/src/libs/pixsaur-raster/optimize-line-palettes.spec.ts
@@ -784,3 +784,86 @@ describe('optimizeLinePalettesWithIndexBuffer', () => {
     }
   })
 })
+
+// On-grid colors (multiples of 17) so quantizeToCPCPlus is the identity,
+// making quantizedGlobalPalette (= the base palette) predictable.
+const onGridColor = (i: number): Vector<'RGB'> => [255, 17 * i, 0]
+const blackColor: Vector<'RGB'> = [0, 0, 0]
+
+function tinyMode0Image(): ImageData {
+  const width = 2
+  const height = 2
+  const data = new Uint8ClampedArray(width * height * 4)
+  for (let i = 0; i < data.length; i += 4) {
+    data[i] = 255
+    data[i + 3] = 255
+  }
+  return new ImageData(data, width, height)
+}
+
+describe('setupMode0PlusPalette (via optimizer, Mode 0 CPC Plus)', () => {
+  const onGrid = onGridColor
+  const black = blackColor
+  const tinyImage = tinyMode0Image
+
+  it('reserves the four raster slots as black', () => {
+    const result = optimizeLinePalettesWithIndexBuffer(tinyImage(), [], [], {
+      nColors: 16
+    })
+
+    expect(result.quantizedGlobalPalette.slice(0, 4)).toEqual([
+      black,
+      black,
+      black,
+      black
+    ])
+  })
+
+  it('keeps a full 16-color base palette', () => {
+    const result = optimizeLinePalettesWithIndexBuffer(tinyImage(), [], [], {
+      nColors: 16
+    })
+
+    expect(result.quantizedGlobalPalette).toHaveLength(16)
+  })
+
+  it('uses a provided palette of exactly numFixedColors as the fixed colors', () => {
+    const provided = Array.from({ length: 12 }, (_, i) => onGrid(i))
+
+    const result = optimizeLinePalettesWithIndexBuffer(
+      tinyImage(),
+      provided,
+      [],
+      { nColors: 16, useProvidedPalette: true }
+    )
+
+    expect(result.quantizedGlobalPalette.slice(4)).toEqual(provided)
+  })
+
+  it('drops the leading raster slots of an oversized provided palette', () => {
+    const provided = Array.from({ length: 16 }, (_, i) => onGrid(i))
+
+    const result = optimizeLinePalettesWithIndexBuffer(
+      tinyImage(),
+      provided,
+      [],
+      { nColors: 16, useProvidedPalette: true }
+    )
+
+    // numRasterSlots = 4, so fixed colors start at provided[4]
+    expect(result.quantizedGlobalPalette[4]).toEqual(onGrid(4))
+  })
+
+  it('fills fixed slots from a too-short provided palette then pads', () => {
+    const provided = [onGrid(0), onGrid(1), onGrid(2)]
+
+    const result = optimizeLinePalettesWithIndexBuffer(
+      tinyImage(),
+      provided,
+      [],
+      { nColors: 16, useProvidedPalette: true }
+    )
+
+    expect(result.quantizedGlobalPalette.slice(4, 7)).toEqual(provided)
+  })
+})


### PR DESCRIPTION
Second S3776 batch: three more pure functions, in files **not touched by #343** (no conflict).

| Function | File | Complexity | Change |
|---|---|---|---|
| `applyEGXOrderedDithering` | pixsaur-egx/dithering.ts | 17→<15 | extract `isAtGamutBoundary` + `perturbForOrderedDithering` |
| `assignColorsToInks` | pixsaur-raster/ink-assignment.ts | 16→<15 | split into `assignExactMatches` + `assignRemainingToFreeInks`; **new spec (7 tests)** |
| `setupMode0PlusPalette` | pixsaur-raster/line-palette-optimizer.ts | 16→<15 | extract `resolveMode0PlusFixedColors` (guard clauses); **+5 characterization tests** |

## Safety
- **Pure extractions, zero behavior change.**
- `dithering.ts`: covered by existing 35 specs (incl. `useOrderedCorrection` on/off).
- `ink-assignment.ts`: had no spec → added `ink-assignment.spec.ts` (empty line, in-place match, free-slot fill, overflow drop, dedup) passing against the pre-refactor code first.
- `line-palette-optimizer.ts`: `setupMode0PlusPalette` is internal → drove all 4 resolution branches through the optimizer using on-grid colors (multiples of 17 ⇒ identity quantization) and asserting on `quantizedGlobalPalette`.
- Avoided introducing new Sonar smells (S3516 early-return, S7721 nested function) flagged live during editing.
- Full `pixsaur-raster` + `pixsaur-egx`: **153 tests green**. typecheck + biome + guards pass.

Closes 3 more `typescript:S3776` (6/39 total with #343). Independent of #343 — mergeable in any order.